### PR TITLE
Standardize on `Uint`

### DIFF
--- a/src/aiff/aiffFile.ts
+++ b/src/aiff/aiffFile.ts
@@ -121,7 +121,7 @@ export default class AiffFile extends File {
                     }
 
                     id3Chunk.addByteVector(AiffFile.id3Identifier);
-                    id3Chunk.addByteVector(ByteVector.fromUInt(tagData.length, true));
+                    id3Chunk.addByteVector(ByteVector.fromUint(tagData.length, true));
                     id3Chunk.addByteVector(tagData);
                 }
             }
@@ -146,7 +146,7 @@ export default class AiffFile extends File {
                     length -= 8;
                 }
 
-                this.insert(ByteVector.fromUInt(readResult.aiffSize + id3Chunk.length - length, true), 4, 4);
+                this.insert(ByteVector.fromUint(readResult.aiffSize + id3Chunk.length - length, true), 4, 4);
             }
 
             // Update the tag types
@@ -176,7 +176,7 @@ export default class AiffFile extends File {
                 } else {
                     // This chunk is not the one we are looking for
                     // Continue the search, seeking over the chunk
-                    const chunkSize = this.readBlock(4).toUInt();
+                    const chunkSize = this.readBlock(4).toUint();
                     this.seek(chunkSize, SeekOrigin.Current);
                 }
             }
@@ -195,7 +195,7 @@ export default class AiffFile extends File {
             throw new CorruptFileError("File does not begin with AIFF identifier");
         }
 
-        const aiffSize = this.readBlock(4).toUInt(true);
+        const aiffSize = this.readBlock(4).toUint(true);
         let tagStart = -1;
         let tagEnd = -1;
 
@@ -241,7 +241,7 @@ export default class AiffFile extends File {
 
             // Get the length of the tag from the ID3 chunk
             this.seek(id3ChunkPos + 4);
-            const tagSize = this.readBlock(4).toUInt(true) + 8;
+            const tagSize = this.readBlock(4).toUint(true) + 8;
 
             tagStart = id3ChunkPos;
             tagEnd = tagStart + tagSize;

--- a/src/aiff/aiffStreamHeader.ts
+++ b/src/aiff/aiffStreamHeader.ts
@@ -47,7 +47,7 @@ export default class AiffStreamHeader implements ILosslessAudioCodec {
         // The first 8 bytes contain the common chunk identifier "COMM" and the size of the common
         // chunk, which is always 18
         this._channels = data.mid(8, 2).toUShort(true);
-        this._totalFrames = data.mid(10, 4).toUInt(true);
+        this._totalFrames = data.mid(10, 4).toUint(true);
         this._bitsPerSample = data.mid(14, 2).toUShort(true);
         this._sampleRate = NumberUtils.convertFromIeeeExtended(data.mid(16, 10));
     }

--- a/src/ape/apeStreamHeader.ts
+++ b/src/ape/apeStreamHeader.ts
@@ -127,12 +127,12 @@ export class ApeStreamHeader implements IAudioCodec, ILosslessAudioCodec {
         this._streamLength = streamLength;
         this._version = data.mid(4, 2).toUShort(false);
         this._compression = <ApeCompressionLevel> data.mid(52, 2).toUShort(false);
-        this._blocksPerFrame = data.mid(56, 4).toUInt(false);
-        this._finalFrameBlocks = data.mid(60, 4).toUInt(false);
-        this._totalFrames = data.mid(64, 4).toUInt(false);
+        this._blocksPerFrame = data.mid(56, 4).toUint(false);
+        this._finalFrameBlocks = data.mid(60, 4).toUint(false);
+        this._totalFrames = data.mid(64, 4).toUint(false);
         this._bitsPerSample = data.mid(68, 2).toUShort(false);
         this._channels = data.mid(70, 2).toUShort(false);
-        this._sampleRate = data.mid(72, 4).toUInt(false);
+        this._sampleRate = data.mid(72, 4).toUint(false);
     }
 
     // #region Properties

--- a/src/ape/apeTag.ts
+++ b/src/ape/apeTag.ts
@@ -278,22 +278,22 @@ export default class ApeTag extends Tag {
     set year(value: number) { this.setNumericValue("Year", value, 0); }
 
     /** @inheritDoc via Track item numerator */
-    get track(): number { return this.getUInt32Value("Track", 0); }
+    get track(): number { return this.getUint32Value("Track", 0); }
     /** @inheritDoc via Track item numerator */
     set track(value: number) { this.setNumericValue("Track", value, this.trackCount); }
 
     /** @inheritDoc via Track item denominator */
-    get trackCount(): number { return this.getUInt32Value("Track", 1); }
+    get trackCount(): number { return this.getUint32Value("Track", 1); }
     /** @inheritDoc via Track item denominator */
     set trackCount(value: number) { this.setNumericValue("Track", this.track, value); }
 
     /** @inheritDoc via Disc item numerator */
-    get disc(): number { return this.getUInt32Value("Disc", 0); }
+    get disc(): number { return this.getUint32Value("Disc", 0); }
     /** @inheritDoc via Disc item numerator */
     set disc(value: number) { this.setNumericValue("Disc", value, this.discCount); }
 
     /** @inheritDoc via Disc item denominator */
-    get discCount(): number { return this.getUInt32Value("Disc", 1); }
+    get discCount(): number { return this.getUint32Value("Disc", 1); }
     /** @inheritDoc via Disc item denominator */
     set discCount(value: number) { this.setNumericValue("Disc", this.disc, value); }
 
@@ -308,7 +308,7 @@ export default class ApeTag extends Tag {
     set grouping(value: string) { this.setStringValue("Grouping", value); }
 
     /** @inheritDoc via BPM item */
-    get beatsPerMinute(): number { return this.getUInt32Value("BPM", 0); }
+    get beatsPerMinute(): number { return this.getUint32Value("BPM", 0); }
     /** @inheritDoc via BPM item */
     set beatsPerMinute(value: number) { this.setNumericValue("BPM", value, 0); }
 
@@ -739,7 +739,7 @@ export default class ApeTag extends Tag {
         return item ? item.text : [];
     }
 
-    private getUInt32Value(key: string, index: number): number {
+    private getUint32Value(key: string, index: number): number {
         const text = this.getStringValue(key);
         if (!text) {
             return 0;

--- a/src/ape/apeTagFooter.ts
+++ b/src/ape/apeTagFooter.ts
@@ -61,11 +61,11 @@ export class ApeTagFooter {
         }
 
         const footer = new ApeTagFooter();
-        footer._version = data.mid(8, 4).toUInt(false);
-        footer._itemCount = data.mid(16, 4).toUInt(false);
-        footer._flags = <ApeTagFooterFlags> data.mid(20, 4).toUInt(false);
+        footer._version = data.mid(8, 4).toUint(false);
+        footer._itemCount = data.mid(16, 4).toUint(false);
+        footer._flags = <ApeTagFooterFlags> data.mid(20, 4).toUint(false);
 
-        const itemPlusFooterSize = footer._itemSize = data.mid(12, 4).toUInt(false);
+        const itemPlusFooterSize = footer._itemSize = data.mid(12, 4).toUint(false);
         if (itemPlusFooterSize < ApeTagFooter.size) {
             throw new CorruptFileError("Tag size is out of bounds");
         }
@@ -166,13 +166,13 @@ export class ApeTagFooter {
 
             // Add the version number -- we always render a 2.000 tag regardless of what the tag
             // originally was.
-            ByteVector.fromUInt(2000, false),
+            ByteVector.fromUint(2000, false),
 
             // Add the tag size
-            ByteVector.fromUInt(this.itemSize + ApeTagFooter.size, false),
+            ByteVector.fromUint(this.itemSize + ApeTagFooter.size, false),
 
             // Add the item count
-            ByteVector.fromUInt(this.itemCount, false)
+            ByteVector.fromUint(this.itemCount, false)
         );
 
         // Render and add the flags
@@ -187,7 +187,7 @@ export class ApeTagFooter {
         } else {
             flags = (flags & ~ApeTagFooterFlags.IsHeader) >>> 0;
         }
-        v.addByteVector(ByteVector.fromUInt(flags, false));
+        v.addByteVector(ByteVector.fromUint(flags, false));
 
         // Add the reserved 64bit
         v.addByteVector(ByteVector.fromSize(8));

--- a/src/ape/apeTagItem.ts
+++ b/src/ape/apeTagItem.ts
@@ -69,8 +69,8 @@ export class ApeTagItem {
             throw new CorruptFileError("Not enough data for APE item");
         }
 
-        const valueLength = data.mid(offset, 4).toUInt(false);
-        const flags = data.mid(offset + 4, 4).toUInt(false);
+        const valueLength = data.mid(offset, 4).toUint(false);
+        const flags = data.mid(offset + 4, 4).toUint(false);
 
         // Read flag data
         item._isReadonly = (flags & 1) > 0;
@@ -210,8 +210,8 @@ export class ApeTagItem {
         // Calculate the flags and length
         let flags = this._isReadonly ? 1 : 0;
         flags |= this._type << 1;
-        const flagsVector = ByteVector.fromUInt(flags, false);
-        const sizeVector = ByteVector.fromUInt(value.length, false);
+        const flagsVector = ByteVector.fromUint(flags, false);
+        const sizeVector = ByteVector.fromUint(value.length, false);
 
         // Put it all together
         const output = ByteVector.concatenate(

--- a/src/asf/asfTag.ts
+++ b/src/asf/asfTag.ts
@@ -917,7 +917,7 @@ export default class AsfTag extends Tag {
         offset += 1;
 
         // Get the Picture size
-        const pictureSize = data.mid(offset, 4).toUInt(false);
+        const pictureSize = data.mid(offset, 4).toUint(false);
         offset += 4;
 
         // Get the mime-type

--- a/src/asf/readWriteUtils.ts
+++ b/src/asf/readWriteUtils.ts
@@ -12,7 +12,7 @@ export default {
      * @param file File to read the double word from
      */
     readDWord: (file: File): number => {
-        return file.readBlock(4).toUInt(false);
+        return file.readBlock(4).toUint(false);
     },
 
     /**
@@ -57,7 +57,7 @@ export default {
      * @param value Double word to render
      */
     renderDWord: (value: number): ByteVector => {
-        return ByteVector.fromUInt(value, false);
+        return ByteVector.fromUint(value, false);
     },
 
     /**

--- a/src/byteVector.ts
+++ b/src/byteVector.ts
@@ -488,7 +488,7 @@ export class ByteVector {
      *        format. If `false`, `value` will be stored in little endian format
      * @param isReadOnly If `true` then the ByteVector will be read only
      */
-    public static fromUInt(
+    public static fromUint(
         value: number,
         mostSignificantByteFirst: boolean = true,
         isReadOnly: boolean = false
@@ -1246,7 +1246,7 @@ export class ByteVector {
      *        endian format)
      * @returns An unsigned integer value containing the value read from the current instance
      */
-    public toUInt(mostSignificantByteFirst: boolean = true): number {
+    public toUint(mostSignificantByteFirst: boolean = true): number {
         const dv = new DataView(this.getSizedArray(4, mostSignificantByteFirst).buffer);
         return dv.getUint32(0);
     }

--- a/src/flac/flacBlock.ts
+++ b/src/flac/flacBlock.ts
@@ -78,7 +78,7 @@ export class FlacBlock implements ILazy {
         block._file = file;
         block._blockStart = position;
 
-        const headerBytes = file.readBlock(4).toUInt();
+        const headerBytes = file.readBlock(4).toUint();
         block._dataSize = NumberUtils.uintAnd(headerBytes, 0x00ffffff);
         block._isLastBlock = !!NumberUtils.uintAnd(headerBytes, 0x80000000);
         block._type = NumberUtils.uintAnd(headerBytes, 0x7f000000) >>> 24;
@@ -176,7 +176,7 @@ export class FlacBlock implements ILazy {
         // Read the data from the file
         const originalFileMode = this._file.mode;
         try {
-            this._file.mode = FileAccessMode.Read
+            this._file.mode = FileAccessMode.Read;
             this._file.seek(this._blockStart + FlacBlock.headerSize);
             this._data = this._file.readBlock(this._dataSize);
         } finally {
@@ -202,7 +202,7 @@ export class FlacBlock implements ILazy {
         );
 
         return ByteVector.concatenate(
-            ByteVector.fromUInt(header),
+            ByteVector.fromUint(header),
             this._data
         );
     }

--- a/src/flac/flacStreamHeader.ts
+++ b/src/flac/flacStreamHeader.ts
@@ -29,9 +29,9 @@ export default class FlacStreamHeader implements ILosslessAudioCodec {
         // See https://www.xiph.org/flac/format.html#metadata_block_streaminfo for the details of
         // how the header is defined
         // NOTE: We're completely ignoring block/frame size
-        const int2 = data.mid(8, 4).toUInt(true);
-        const int3 = data.mid(12, 4).toUInt(true);
-        const int4 = data.mid(16, 4).toUInt(true);
+        const int2 = data.mid(8, 4).toUint(true);
+        const int3 = data.mid(12, 4).toUint(true);
+        const int4 = data.mid(16, 4).toUint(true);
 
         // # of channels is bits 100-103
         this._audioChannels = NumberUtils.uintRShift(NumberUtils.uintAnd(int3, 0x0E000000), 25) + 1;

--- a/src/id3v2/frames/frame.ts
+++ b/src/id3v2/frames/frame.ts
@@ -166,7 +166,7 @@ export abstract class Frame {
         const frontData = ByteVector.empty();
 
         if ((this.flags & (Id3v2FrameFlags.Compression | Id3v2FrameFlags.DataLengthIndicator)) !== 0) {
-            frontData.addByteVector(ByteVector.fromUInt(fieldData.length));
+            frontData.addByteVector(ByteVector.fromUint(fieldData.length));
         }
         if ((this.flags & Id3v2FrameFlags.GroupingIdentity) !== 0) {
             frontData.addByte(this._groupId);

--- a/src/id3v2/frames/frameHeader.ts
+++ b/src/id3v2/frames/frameHeader.ts
@@ -108,7 +108,7 @@ export class Id3v2FrameHeader {
                     break;
                 }
 
-                frameSize = data.mid(3, 3).toUInt();
+                frameSize = data.mid(3, 3).toUint();
                 break;
 
             case 3:
@@ -126,7 +126,7 @@ export class Id3v2FrameHeader {
                 }
 
                 // Store the flags internally as version 2.4
-                frameSize = data.mid(4, 4).toUInt();
+                frameSize = data.mid(4, 4).toUint();
                 flags = ((data.get(8) << 7) & 0x7000)
                     | ((data.get(9) >> 4) & 0x000C)
                     | ((data.get(9) << 1) & 0x0040);
@@ -225,7 +225,7 @@ export class Id3v2FrameHeader {
 
         switch (version) {
             case 2:
-                data.addByteVector(ByteVector.fromUInt(this._frameSize).mid(1, 3));
+                data.addByteVector(ByteVector.fromUint(this._frameSize).mid(1, 3));
                 break;
 
             case 3:
@@ -233,7 +233,7 @@ export class Id3v2FrameHeader {
                     | (this._flags << 4) & 0x00C0
                     | (this._flags >> 1) & 0x0020;
 
-                data.addByteVector(ByteVector.fromUInt(this._frameSize));
+                data.addByteVector(ByteVector.fromUint(this._frameSize));
                 data.addByteVector(ByteVector.fromUShort(newFlags));
                 break;
 

--- a/src/id3v2/frames/synchronizedLyricsFrame.ts
+++ b/src/id3v2/frames/synchronizedLyricsFrame.ts
@@ -60,7 +60,7 @@ export class SynchronizedText {
         return ByteVector.concatenate(
             ByteVector.fromString(this.text, encoding),
             ByteVector.getTextDelimiter(encoding),
-            ByteVector.fromUInt(this.time)
+            ByteVector.fromUint(this.time)
         );
     }
 }
@@ -345,7 +345,7 @@ export class SynchronizedLyricsFrame extends Frame {
                 break;
             }
 
-            const time = data.mid(offset, 4).toUInt();
+            const time = data.mid(offset, 4).toUint();
             l.push(new SynchronizedText(time, text));
 
             offset += 4;

--- a/src/mpeg/mpegAudioHeader.ts
+++ b/src/mpeg/mpegAudioHeader.ts
@@ -77,7 +77,7 @@ export default class MpegAudioHeader implements IAudioCodec {
             throw new CorruptFileError(error);
         }
 
-        header._flags = data.toUInt();
+        header._flags = data.toUint();
         header._xingHeader = XingHeader.unknown;
         header._vbriHeader = VbriHeader.unknown;
 
@@ -393,7 +393,7 @@ export default class MpegAudioHeader implements IAudioCodec {
             return "Second byte did not match MPEG sync";
         }
 
-        const flags = data.toUInt();
+        const flags = data.toUint();
         if (((flags >> 12) & 0x0F) === 0x0F) {
             return "Header uses invalid bitrate index";
         }

--- a/src/mpeg/mpegVideoHeader.ts
+++ b/src/mpeg/mpegVideoHeader.ts
@@ -36,7 +36,7 @@ export default class MpegVideoHeader implements IVideoCodec {
         this._videoWidth = data.mid(0, 2).toUShort() >>> 4;
         this._videoHeight = (data.mid(1, 2).toShort() & 0x0FFF) >>> 0;
         this._frameRateIndex = (data.get(3) & 0x0F) >>> 0;
-        this._videoBitrate = ((data.mid(4, 3).toUInt() >>> 6) & 0x3FFFF) >>> 0;
+        this._videoBitrate = ((data.mid(4, 3).toUint() >>> 6) & 0x3FFFF) >>> 0;
     }
 
     // #region

--- a/src/mpeg/vbriHeader.ts
+++ b/src/mpeg/vbriHeader.ts
@@ -60,8 +60,8 @@ export default class VbriHeader {
 
         // Size start at position 10
         const header = new VbriHeader();
-        header._totalSize = data.mid(10, 4).toUInt();
-        header._totalFrames = data.mid(14, 4).toUInt();
+        header._totalSize = data.mid(10, 4).toUint();
+        header._totalFrames = data.mid(14, 4).toUint();
         header._isPresent = true;
 
         return header;

--- a/src/mpeg/xingHeader.ts
+++ b/src/mpeg/xingHeader.ts
@@ -57,14 +57,14 @@ export default class XingHeader {
         let position = 8;
 
         if ((data.get(7) & 0x01) !== 0) {
-            header._totalFrames = data.mid(position, 4).toUInt();
+            header._totalFrames = data.mid(position, 4).toUint();
             position += 4;
         } else {
             header._totalFrames = 0;
         }
 
         if ((data.get(7) & 0x02) !== 0) {
-            header._totalSize = data.mid(position, 4).toUInt();
+            header._totalSize = data.mid(position, 4).toUint();
         } else {
             header._totalSize = 0;
         }

--- a/src/riff/avi/aviHeader.ts
+++ b/src/riff/avi/aviHeader.ts
@@ -50,15 +50,15 @@ export default class AviHeader {
         if (mainHeaderData.length < 40) {
             throw new CorruptFileError("AVI header is an invalid length");
         }
-        this._microsecondsPerFrame = mainHeaderData.mid(0, 4).toUInt(false);
-        this._maxBytesPerSecond = mainHeaderData.mid(4, 4).toUInt(false);
-        this._flags = mainHeaderData.mid(12, 4).toUInt(false);
-        this._totalFrames = mainHeaderData.mid(16, 4).toUInt(false);
-        this._initialFrames = mainHeaderData.mid(20, 4).toUInt(false);
-        this._streamCount = mainHeaderData.mid(24, 4).toUInt(false);
-        this._suggestedBufferSize = mainHeaderData.mid(28, 4).toUInt(false);
-        this._width = mainHeaderData.mid(32, 4).toUInt(false);
-        this._height = mainHeaderData.mid(36, 4).toUInt(false);
+        this._microsecondsPerFrame = mainHeaderData.mid(0, 4).toUint(false);
+        this._maxBytesPerSecond = mainHeaderData.mid(4, 4).toUint(false);
+        this._flags = mainHeaderData.mid(12, 4).toUint(false);
+        this._totalFrames = mainHeaderData.mid(16, 4).toUint(false);
+        this._initialFrames = mainHeaderData.mid(20, 4).toUint(false);
+        this._streamCount = mainHeaderData.mid(24, 4).toUint(false);
+        this._suggestedBufferSize = mainHeaderData.mid(28, 4).toUint(false);
+        this._width = mainHeaderData.mid(32, 4).toUint(false);
+        this._height = mainHeaderData.mid(36, 4).toUint(false);
 
         this._durationMilliseconds = this._totalFrames * this._microsecondsPerFrame / 1000;
 

--- a/src/riff/avi/aviStream.ts
+++ b/src/riff/avi/aviStream.ts
@@ -67,19 +67,19 @@ export class AviStream {
             throw new CorruptFileError("Stream header does not contain correct number of bytes");
         }
 
-        this._type = streamHeaderDatum.mid(0, 4).toUInt(false);
-        this._handler = streamHeaderDatum.mid(4, 4).toUInt(false);
-        this._flags = streamHeaderDatum.mid(8, 4).toUInt(false);
+        this._type = streamHeaderDatum.mid(0, 4).toUint(false);
+        this._handler = streamHeaderDatum.mid(4, 4).toUint(false);
+        this._flags = streamHeaderDatum.mid(8, 4).toUint(false);
         this._priority = streamHeaderDatum.mid(12, 2).toUShort(false);
         this._language = streamHeaderDatum.mid(14, 2).toUShort(false);
-        this._initialFrames = streamHeaderDatum.mid(16, 4).toUInt(false);
-        this._scale = streamHeaderDatum.mid(20, 4).toUInt(false);
-        this._rate = streamHeaderDatum.mid(24, 4).toUInt(false);
-        this._start = streamHeaderDatum.mid(28, 4).toUInt(false);
-        this._length = streamHeaderDatum.mid(32, 4).toUInt(false);
-        this._suggestedBufferSize = streamHeaderDatum.mid(36, 4).toUInt(false);
-        this._quality = streamHeaderDatum.mid(40, 4).toUInt(false);
-        this._sampleSize = streamHeaderDatum.mid(44, 4).toUInt(false);
+        this._initialFrames = streamHeaderDatum.mid(16, 4).toUint(false);
+        this._scale = streamHeaderDatum.mid(20, 4).toUint(false);
+        this._rate = streamHeaderDatum.mid(24, 4).toUint(false);
+        this._start = streamHeaderDatum.mid(28, 4).toUint(false);
+        this._length = streamHeaderDatum.mid(32, 4).toUint(false);
+        this._suggestedBufferSize = streamHeaderDatum.mid(36, 4).toUint(false);
+        this._quality = streamHeaderDatum.mid(40, 4).toUint(false);
+        this._sampleSize = streamHeaderDatum.mid(44, 4).toUint(false);
         this._left = streamHeaderDatum.mid(48, 2).toUShort(false);
         this._top = streamHeaderDatum.mid(50, 2).toUShort(false);
         this._right = streamHeaderDatum.mid(52, 2).toUShort(false);

--- a/src/riff/riffBitmapInfoHeader.ts
+++ b/src/riff/riffBitmapInfoHeader.ts
@@ -700,16 +700,16 @@ export default class RiffBitmapInfoHeader implements IVideoCodec {
             throw new CorruptFileError("Expected at least 40 bytes for bitmap info header");
         }
 
-        this._width = data.mid(offset + 4, 4).toUInt(false);
-        this._height = data.mid(offset + 8, 4).toUInt(false);
+        this._width = data.mid(offset + 4, 4).toUint(false);
+        this._height = data.mid(offset + 8, 4).toUint(false);
         this._planes = data.mid(offset + 12, 2).toUShort(false);
         this._bitCount = data.mid(offset + 14, 2).toUShort(false);
-        this._compressionId = data.mid(offset + 16, 4).toUInt(false);
-        this._imageSize = data.mid(offset + 20, 4).toUInt(false);
-        this._xPixelsPerMeter = data.mid(offset + 24, 4).toUInt(false);
-        this._yPixelsPerMeter = data.mid(offset + 28, 4).toUInt(false);
-        this._colorsUsed = data.mid(offset + 32, 4).toUInt(false);
-        this._importantColors = data.mid(offset + 36, 4).toUInt(false);
+        this._compressionId = data.mid(offset + 16, 4).toUint(false);
+        this._imageSize = data.mid(offset + 20, 4).toUint(false);
+        this._xPixelsPerMeter = data.mid(offset + 24, 4).toUint(false);
+        this._yPixelsPerMeter = data.mid(offset + 28, 4).toUint(false);
+        this._colorsUsed = data.mid(offset + 32, 4).toUint(false);
+        this._importantColors = data.mid(offset + 36, 4).toUint(false);
     }
 
     // #region Properties

--- a/src/riff/riffChunk.ts
+++ b/src/riff/riffChunk.ts
@@ -37,7 +37,7 @@ export default class RiffChunk implements IRiffChunk, ILazy {
 
         const chunk = new RiffChunk();
         file.seek(position + 4);
-        chunk._originalDataSize = file.readBlock(4).toUInt(false);
+        chunk._originalDataSize = file.readBlock(4).toUint(false);
         chunk._file = file;
         chunk._fourcc = fourcc;
         chunk._chunkStart = position;
@@ -123,7 +123,7 @@ export default class RiffChunk implements IRiffChunk, ILazy {
 
         const data = ByteVector.concatenate(
             ByteVector.fromString(this._fourcc),
-            ByteVector.fromUInt(this.data.length, false),
+            ByteVector.fromUint(this.data.length, false),
             this._data
         );
         if ((data.length + 4) % 2 === 1) {

--- a/src/riff/riffFile.ts
+++ b/src/riff/riffFile.ts
@@ -273,7 +273,7 @@ export default class RiffFile extends File {
 
             // Calculate new RIFF size
             this._riffSize = this.length - 8;
-            this.insert(ByteVector.fromUInt(this._riffSize, false), 4, 4);
+            this.insert(ByteVector.fromUint(this._riffSize, false), 4, 4);
             this._tagTypesOnDisk = this.tagTypes;
         } finally {
             this.mode = FileAccessMode.Closed;
@@ -288,7 +288,7 @@ export default class RiffFile extends File {
             if (!ByteVector.equal(this.readBlock(4), RiffFile.fileIdentifier)) {
                 throw new CorruptFileError("File does not begin with RIFF identifier");
             }
-            this._riffSize = this.readBlock(4).toUInt(false);
+            this._riffSize = this.readBlock(4).toUint(false);
             this._fileType = this.readBlock(4).toString();
 
             // Read chunks until there are less than 8 bytes to read

--- a/src/riff/riffList.ts
+++ b/src/riff/riffList.ts
@@ -53,7 +53,7 @@ export default class RiffList implements IRiffChunk, ILazy {
 
         const list = new RiffList();
         list._chunkStart = position;
-        list._originalDataSize = file.readBlock(4).toUInt(false);
+        list._originalDataSize = file.readBlock(4).toUint(false);
         list._file = file;
         list._isLoaded = false;
         list._type = file.readBlock(4).toString();
@@ -174,7 +174,7 @@ export default class RiffList implements IRiffChunk, ILazy {
                 this._file.seek(fileOffset);
                 const headerBlock = this._file.readBlock(8);
                 const id = headerBlock.toString(4);
-                const length = headerBlock.mid(4, 4).toUInt(false);
+                const length = headerBlock.mid(4, 4).toUint(false);
 
                 if (id === RiffList.identifierFourcc) {
                     // The element is a list, create a nested riff list from it
@@ -244,7 +244,7 @@ export default class RiffList implements IRiffChunk, ILazy {
             const valuesBytes = value.map((v) => {
                 const valueBytes = ByteVector.concatenate(
                     ByteVector.fromString(key),
-                    ByteVector.fromUInt(v.length, false),
+                    ByteVector.fromUint(v.length, false),
                     v
                 );
                 if (v.length % 2 === 1) {
@@ -270,7 +270,7 @@ export default class RiffList implements IRiffChunk, ILazy {
 
         const data = ByteVector.concatenate(
             ByteVector.fromString(RiffList.identifierFourcc),
-            ByteVector.fromUInt(allData.length + 4, false),
+            ByteVector.fromUint(allData.length + 4, false),
             ByteVector.fromString(this._type),
             allData
         );

--- a/src/riff/riffWaveFormatEx.ts
+++ b/src/riff/riffWaveFormatEx.ts
@@ -302,8 +302,8 @@ export default class RiffWaveFormatEx implements ILosslessAudioCodec {
 
         this._formatTag = data.mid(0, 2).toUShort(false);
         this._channels = data.mid(2, 2).toUShort(false);
-        this._samplesPerSecond = data.mid(4, 4).toUInt(false);
-        this._averageBytesPerSecond = data.mid(8, 4).toUInt(false);
+        this._samplesPerSecond = data.mid(4, 4).toUint(false);
+        this._averageBytesPerSecond = data.mid(8, 4).toUint(false);
         this._blockAlign = data.mid(12, 2).toUShort(false);
         this._bitsPerSample = data.mid(14, 2).toUShort(false);
     }

--- a/src/xiph/xiphComment.ts
+++ b/src/xiph/xiphComment.ts
@@ -42,19 +42,19 @@ export default class XiphComment extends Tag {
         // The first thing in the comment data is the vendor ID length, followed by a UTF8 string
         // with the vendor ID.
         let pos = 0;
-        const vendorLength = data.mid(pos, 4).toUInt(false);
+        const vendorLength = data.mid(pos, 4).toUint(false);
         pos += 4;
         xiphComment._vendorId = data.toString(vendorLength, StringType.UTF8, pos);
         pos += vendorLength;
 
         // Next, the number of fields in the comment vector
-        const commentFields = data.mid(pos, 4).toUInt(false);
+        const commentFields = data.mid(pos, 4).toUint(false);
         pos += 4;
 
         for (let i = 0; i < commentFields; i++) {
             // Each comment field is in the format KEY=value in a UTF8 string and has a 32-bit uint
             // before it with the length.
-            const commentLength = data.mid(pos, 4).toUInt(false);
+            const commentLength = data.mid(pos, 4).toUint(false);
             pos += 4;
             const comment = data.toString(commentLength, StringType.UTF8, pos);
             pos += commentLength;
@@ -846,7 +846,7 @@ export default class XiphComment extends Tag {
                 const encodedField = `${k}=${v}`;
                 const fieldDatum = ByteVector.fromString(encodedField, StringType.UTF8);
                 return ByteVector.concatenate(
-                    ByteVector.fromUInt(fieldDatum.length, false),
+                    ByteVector.fromUint(fieldDatum.length, false),
                     fieldDatum
                 );
             });
@@ -861,16 +861,16 @@ export default class XiphComment extends Tag {
             const xiphPicture = p instanceof XiphPicture ? p : XiphPicture.fromPicture(p);
             const encodedPicture = `${XiphComment.newPictureFiled}=${xiphPicture.renderForXiphComment()}`;
             return ByteVector.concatenate(
-                ByteVector.fromUInt(encodedPicture.length, false),
+                ByteVector.fromUint(encodedPicture.length, false),
                 ByteVector.fromString(encodedPicture, StringType.UTF8)
             );
         });
 
         // Put it all together
         const result = ByteVector.concatenate(
-            ByteVector.fromUInt(vendor.length, false),
+            ByteVector.fromUint(vendor.length, false),
             vendor,
-            ByteVector.fromUInt(allFieldData.length + pictureData.length, false),
+            ByteVector.fromUint(allFieldData.length + pictureData.length, false),
             ... allFieldData,
             ... pictureData
         );

--- a/src/xiph/xiphPicture.ts
+++ b/src/xiph/xiphPicture.ts
@@ -255,29 +255,29 @@ export default class XiphPicture implements IPicture, ILazy {
 
         let position = 0;
         const rawData = this._rawDataSource();
-        this._type = rawData.mid(position, 4).toUInt();
+        this._type = rawData.mid(position, 4).toUint();
         position += 4;
 
-        const mimetypeLength = rawData.mid(position, 4).toUInt();
+        const mimetypeLength = rawData.mid(position, 4).toUint();
         position += 4;
         this._mimeType = rawData.mid(position, mimetypeLength).toString(undefined, StringType.Latin1);
         position += mimetypeLength;
 
-        const descriptionLength = rawData.mid(position, 4).toUInt();
+        const descriptionLength = rawData.mid(position, 4).toUint();
         position += 4;
         this._description = rawData.mid(position, descriptionLength).toString(undefined, StringType.UTF8);
         position += descriptionLength;
 
-        this._width = rawData.mid(position, 4).toUInt();
+        this._width = rawData.mid(position, 4).toUint();
         position += 4;
-        this._height = rawData.mid(position, 4).toUInt();
+        this._height = rawData.mid(position, 4).toUint();
         position += 4;
-        this._colorDepth = rawData.mid(position, 4).toUInt();
+        this._colorDepth = rawData.mid(position, 4).toUint();
         position += 4;
-        this._indexedColors = rawData.mid(position, 4).toUInt();
+        this._indexedColors = rawData.mid(position, 4).toUint();
         position += 4;
 
-        const dataLength = rawData.mid(position, 4).toUInt();
+        const dataLength = rawData.mid(position, 4).toUint();
         position += 4;
         this._data = rawData.mid(position, dataLength);
     }
@@ -291,16 +291,16 @@ export default class XiphPicture implements IPicture, ILazy {
         const mimeType = ByteVector.fromString(this._mimeType, StringType.Latin1);
         const description = ByteVector.fromString(this._description, StringType.UTF8);
         return ByteVector.concatenate(
-            ByteVector.fromUInt(this._type),
-            ByteVector.fromUInt(mimeType.length),
+            ByteVector.fromUint(this._type),
+            ByteVector.fromUint(mimeType.length),
             mimeType,
-            ByteVector.fromUInt(description.length),
+            ByteVector.fromUint(description.length),
             description,
-            ByteVector.fromUInt(this._width),
-            ByteVector.fromUInt(this._height),
-            ByteVector.fromUInt(this._colorDepth),
-            ByteVector.fromUInt(this._indexedColors),
-            ByteVector.fromUInt(this._data.length),
+            ByteVector.fromUint(this._width),
+            ByteVector.fromUint(this._height),
+            ByteVector.fromUint(this._colorDepth),
+            ByteVector.fromUint(this._indexedColors),
+            ByteVector.fromUint(this._data.length),
             this._data
         );
     }

--- a/test-unit/aiff/aiffStreamHeaderTests.ts
+++ b/test-unit/aiff/aiffStreamHeaderTests.ts
@@ -31,9 +31,9 @@ const assert = Chai.assert;
         // Arrange
         const data = ByteVector.concatenate(
             ByteVector.fromString("COMM"), // Chunk identifier
-            ByteVector.fromUInt(18), // Chunk size
+            ByteVector.fromUint(18), // Chunk size
             ByteVector.fromUShort(1234), // Channels
-            ByteVector.fromUInt(2345), // Total frames
+            ByteVector.fromUint(2345), // Total frames
             ByteVector.fromUShort(3456), // Bits per sample
             // Sample rate (2345678)
             ByteVector.fromByteArray(new Uint8Array([0x40, 0x14, 0x8F, 0x2B, 0x38, 0x00, 0x00, 0x00, 0x00, 0x00]))
@@ -59,9 +59,9 @@ const assert = Chai.assert;
         // Arrange
         const data = ByteVector.concatenate(
             ByteVector.fromString("COMM"), // Chunk identifier
-            ByteVector.fromUInt(18), // Chunk size
+            ByteVector.fromUint(18), // Chunk size
             ByteVector.fromUShort(1234), // Channels
-            ByteVector.fromUInt(2345), // Total frames
+            ByteVector.fromUint(2345), // Total frames
             ByteVector.fromUShort(3456), // Bits per sample
             // Sample rate (0)
             ByteVector.fromByteArray(new Uint8Array([0x3C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
@@ -87,9 +87,9 @@ const assert = Chai.assert;
         // Arrange
         const data = ByteVector.concatenate(
             ByteVector.fromString("COMM"), // Chunk identifier
-            ByteVector.fromUInt(18), // Chunk size
+            ByteVector.fromUint(18), // Chunk size
             ByteVector.fromUShort(1234), // Channels
-            ByteVector.fromUInt(0), // Total frames
+            ByteVector.fromUint(0), // Total frames
             ByteVector.fromUShort(3456), // Bits per sample
             // Sample rate
             ByteVector.fromByteArray(new Uint8Array([0x40, 0x14, 0x8F, 0x2B, 0x38, 0x00, 0x00, 0x00, 0x00, 0x00]))

--- a/test-unit/ape/apeStreamHeaderTests.ts
+++ b/test-unit/ape/apeStreamHeaderTests.ts
@@ -53,12 +53,12 @@ const assert = Chai.assert;
             ByteVector.fromSize(46),
             ByteVector.fromUShort(ApeCompressionLevel.Insane, false), // Compression level (duh)
             ByteVector.fromSize(2),
-            ByteVector.fromUInt(234, false), // Blocks per frame
-            ByteVector.fromUInt(345, false), // Final frame blocks
-            ByteVector.fromUInt(456, false), // Total frames
+            ByteVector.fromUint(234, false), // Blocks per frame
+            ByteVector.fromUint(345, false), // Final frame blocks
+            ByteVector.fromUint(456, false), // Total frames
             ByteVector.fromUShort(567, false), // Bits per sample
             ByteVector.fromUShort(3, false), // Channels
-            ByteVector.fromUInt(678, false), // Sample rate
+            ByteVector.fromUint(678, false), // Sample rate
         );
 
         // Act
@@ -85,12 +85,12 @@ const assert = Chai.assert;
             ByteVector.fromSize(46),
             ByteVector.fromUShort(ApeCompressionLevel.Insane, false), // Compression level (duh)
             ByteVector.fromSize(2),
-            ByteVector.fromUInt(0, false), // Blocks per frame
-            ByteVector.fromUInt(0, false), // Final frame blocks
-            ByteVector.fromUInt(1, false), // Total frames
+            ByteVector.fromUint(0, false), // Blocks per frame
+            ByteVector.fromUint(0, false), // Final frame blocks
+            ByteVector.fromUint(1, false), // Total frames
             ByteVector.fromUShort(567, false), // Bits per sample
             ByteVector.fromUShort(3, false), // Channels
-            ByteVector.fromUInt(678, false), // Sample rate
+            ByteVector.fromUint(678, false), // Sample rate
         );
 
         // Act

--- a/test-unit/ape/apeTagFooterTests.ts
+++ b/test-unit/ape/apeTagFooterTests.ts
@@ -11,10 +11,10 @@ const assert = Chai.assert;
 
 const _sampleData = ByteVector.concatenate(
     ByteVector.fromString("APETAGEX", StringType.Latin1), // File Identifier
-    ByteVector.fromUInt(1234, false), // Version
-    ByteVector.fromUInt(2345, false), // Tag Size
-    ByteVector.fromUInt(3456, false), // Item count
-    ByteVector.fromUInt(ApeTagFooterFlags.IsHeader, false), // Flags
+    ByteVector.fromUint(1234, false), // Version
+    ByteVector.fromUint(2345, false), // Tag Size
+    ByteVector.fromUint(3456, false), // Item count
+    ByteVector.fromUint(ApeTagFooterFlags.IsHeader, false), // Flags
     ByteVector.fromSize(12)
 );
 
@@ -32,10 +32,10 @@ const _sampleData = ByteVector.concatenate(
         // Arrange
         const data = ByteVector.concatenate(
             ByteVector.fromString("APETAGEX", StringType.Latin1), // File Identifier
-            ByteVector.fromUInt(1234, false), // Version
-            ByteVector.fromUInt(10, false), // Tag Size
-            ByteVector.fromUInt(3456, false), // Item count
-            ByteVector.fromUInt(ApeTagFooterFlags.IsHeader, false), // Flags
+            ByteVector.fromUint(1234, false), // Version
+            ByteVector.fromUint(10, false), // Tag Size
+            ByteVector.fromUint(3456, false), // Item count
+            ByteVector.fromUint(ApeTagFooterFlags.IsHeader, false), // Flags
             ByteVector.fromSize(12)
         );
 
@@ -48,10 +48,10 @@ const _sampleData = ByteVector.concatenate(
         // Arrange
         const data = ByteVector.concatenate(
             ByteVector.fromString("APETAGEX", StringType.Latin1), // File Identifier
-            ByteVector.fromUInt(1234, false), // Version
-            ByteVector.fromUInt(2345, false), // Tag Size
-            ByteVector.fromUInt(3456, false), // Item count
-            ByteVector.fromUInt(ApeTagFooterFlags.IsHeader, false), // Flags
+            ByteVector.fromUint(1234, false), // Version
+            ByteVector.fromUint(2345, false), // Tag Size
+            ByteVector.fromUint(3456, false), // Item count
+            ByteVector.fromUint(ApeTagFooterFlags.IsHeader, false), // Flags
             ByteVector.fromSize(12)
         );
 
@@ -72,10 +72,10 @@ const _sampleData = ByteVector.concatenate(
         // Arrange
         const data = ByteVector.concatenate(
             ByteVector.fromString("APETAGEX", StringType.Latin1), // File Identifier
-            ByteVector.fromUInt(0, false), // Version
-            ByteVector.fromUInt(2345, false), // Tag Size
-            ByteVector.fromUInt(3456, false), // Item count
-            ByteVector.fromUInt(ApeTagFooterFlags.HeaderPresent, false), // Flags
+            ByteVector.fromUint(0, false), // Version
+            ByteVector.fromUint(2345, false), // Tag Size
+            ByteVector.fromUint(3456, false), // Item count
+            ByteVector.fromUint(ApeTagFooterFlags.HeaderPresent, false), // Flags
             ByteVector.fromSize(12)
         );
 
@@ -182,10 +182,10 @@ const _sampleData = ByteVector.concatenate(
         // Assert
         const expected = ByteVector.concatenate(
             ByteVector.fromString("APETAGEX", StringType.Latin1), // File Identifier
-            ByteVector.fromUInt(2000, false), // Version
-            ByteVector.fromUInt(2345, false), // Tag Size
-            ByteVector.fromUInt(3456, false), // Item count
-            ByteVector.fromUInt(ApeTagFooterFlags.HeaderPresent, false), // Flags
+            ByteVector.fromUint(2000, false), // Version
+            ByteVector.fromUint(2345, false), // Tag Size
+            ByteVector.fromUint(3456, false), // Item count
+            ByteVector.fromUint(ApeTagFooterFlags.HeaderPresent, false), // Flags
             ByteVector.fromSize(8)
         );
         Testers.bvEqual(output, expected);
@@ -203,10 +203,10 @@ const _sampleData = ByteVector.concatenate(
         // Assert
         const expected = ByteVector.concatenate(
             ByteVector.fromString("APETAGEX", StringType.Latin1), // File Identifier
-            ByteVector.fromUInt(2000, false), // Version
-            ByteVector.fromUInt(2345, false), // Tag Size
-            ByteVector.fromUInt(3456, false), // Item count
-            ByteVector.fromUInt(0, false), // Flags
+            ByteVector.fromUint(2000, false), // Version
+            ByteVector.fromUint(2345, false), // Tag Size
+            ByteVector.fromUint(3456, false), // Item count
+            ByteVector.fromUint(0, false), // Flags
             ByteVector.fromSize(8)
         );
         Testers.bvEqual(output, expected);
@@ -223,10 +223,10 @@ const _sampleData = ByteVector.concatenate(
         // Assert
         const expected = ByteVector.concatenate(
             ByteVector.fromString("APETAGEX", StringType.Latin1), // File Identifier
-            ByteVector.fromUInt(2000, false), // Version
-            ByteVector.fromUInt(2345, false), // Tag Size
-            ByteVector.fromUInt(3456, false), // Item count
-            ByteVector.fromUInt(0, false), // Flags
+            ByteVector.fromUint(2000, false), // Version
+            ByteVector.fromUint(2345, false), // Tag Size
+            ByteVector.fromUint(3456, false), // Item count
+            ByteVector.fromUint(0, false), // Flags
             ByteVector.fromSize(8)
         );
         Testers.bvEqual(output, expected);
@@ -245,10 +245,10 @@ const _sampleData = ByteVector.concatenate(
         const expectedFlags = (ApeTagFooterFlags.HeaderPresent | ApeTagFooterFlags.IsHeader) >>> 0;
         const expected = ByteVector.concatenate(
             ByteVector.fromString("APETAGEX", StringType.Latin1), // File Identifier
-            ByteVector.fromUInt(2000, false), // Version
-            ByteVector.fromUInt(2345, false), // Tag Size
-            ByteVector.fromUInt(3456, false), // Item count
-            ByteVector.fromUInt(expectedFlags, false), // Flags
+            ByteVector.fromUint(2000, false), // Version
+            ByteVector.fromUint(2345, false), // Tag Size
+            ByteVector.fromUint(3456, false), // Item count
+            ByteVector.fromUint(expectedFlags, false), // Flags
             ByteVector.fromSize(8)
         );
         Testers.bvEqual(output, expected);
@@ -280,10 +280,10 @@ const _sampleData = ByteVector.concatenate(
         const expectedFlags = (ApeTagFooterFlags.HeaderPresent | ApeTagFooterFlags.IsHeader) >>> 0;
         const expected = ByteVector.concatenate(
             ByteVector.fromString("APETAGEX", StringType.Latin1), // File Identifier
-            ByteVector.fromUInt(2000, false), // Version
-            ByteVector.fromUInt(2345, false), // Tag Size
-            ByteVector.fromUInt(3456, false), // Item count
-            ByteVector.fromUInt(expectedFlags, false), // Flags
+            ByteVector.fromUint(2000, false), // Version
+            ByteVector.fromUint(2345, false), // Tag Size
+            ByteVector.fromUint(3456, false), // Item count
+            ByteVector.fromUint(expectedFlags, false), // Flags
             ByteVector.fromSize(8)
         );
         Testers.bvEqual(output, expected);

--- a/test-unit/ape/apeTagItemTests.ts
+++ b/test-unit/ape/apeTagItemTests.ts
@@ -98,7 +98,7 @@ const assert = Chai.assert;
         // Arrange
         const data = ByteVector.concatenate(
             0x00, // Offset
-            ByteVector.fromUInt(12, false), // Size,
+            ByteVector.fromUint(12, false), // Size,
             0x00, 0x00, 0x00, 0x00, // Flags
             ByteVector.fromString("foo", StringType.UTF8), // Key
             ByteVector.getTextDelimiter(StringType.UTF8), // End of key
@@ -115,7 +115,7 @@ const assert = Chai.assert;
         const value = ByteVector.fromString("foobarbaz");
         const data = ByteVector.concatenate(
             0x00, // Offset
-            ByteVector.fromUInt(value.length, false), // Size,
+            ByteVector.fromUint(value.length, false), // Size,
             0x03, 0x00, 0x00, 0x00, // Flags
             ByteVector.fromString("foo", StringType.UTF8), // Key
             ByteVector.getTextDelimiter(StringType.UTF8), // End of key
@@ -141,7 +141,7 @@ const assert = Chai.assert;
         // Arrange
         const data = ByteVector.concatenate(
             0x00, // Offset
-            ByteVector.fromUInt(11, false), // Size,
+            ByteVector.fromUint(11, false), // Size,
             0x00, 0x00, 0x00, 0x00, // Flags
             ByteVector.fromString("foo", StringType.UTF8), // Key
             ByteVector.getTextDelimiter(StringType.UTF8), // End of key
@@ -271,7 +271,7 @@ const assert = Chai.assert;
         // Arrange
         const value = ByteVector.fromString("foobarbaz");
         const data = ByteVector.concatenate(
-            ByteVector.fromUInt(value.length, false), // Size,
+            ByteVector.fromUint(value.length, false), // Size,
             0x03, 0x00, 0x00, 0x00, // Flags
             ByteVector.fromString("foo", StringType.UTF8), // Key
             ByteVector.getTextDelimiter(StringType.UTF8), // End of key
@@ -291,7 +291,7 @@ const assert = Chai.assert;
     public render_text() {
         // Arrange
         const data = ByteVector.concatenate(
-            ByteVector.fromUInt(11, false), // Size,
+            ByteVector.fromUint(11, false), // Size,
             0x00, 0x00, 0x00, 0x00, // Flags
             ByteVector.fromString("foo", StringType.UTF8), // Key
             ByteVector.getTextDelimiter(StringType.UTF8), // End of key

--- a/test-unit/ape/apeTagTests.ts
+++ b/test-unit/ape/apeTagTests.ts
@@ -19,10 +19,10 @@ const assert = Chai.assert;
 function getTestTagFooter(flags: ApeTagFooterFlags, itemCount: number, itemPlusFooter: number): ByteVector {
     return ByteVector.concatenate(
         ApeTagFooter.fileIdentifier,
-        ByteVector.fromUInt(2000, false),
-        ByteVector.fromUInt(itemPlusFooter, false),
-        ByteVector.fromUInt(itemCount, false),
-        ByteVector.fromUInt(flags, false),
+        ByteVector.fromUint(2000, false),
+        ByteVector.fromUint(itemPlusFooter, false),
+        ByteVector.fromUint(itemCount, false),
+        ByteVector.fromUint(flags, false),
         ByteVector.fromSize(8)
     );
 }

--- a/test-unit/asf/asfTagTests.ts
+++ b/test-unit/asf/asfTagTests.ts
@@ -29,7 +29,7 @@ const getHeaderObject: (children: BaseObject[]) => HeaderObject = (children: Bas
     const headerBytes = ByteVector.concatenate(
         Guids.AsfHeaderObject.toBytes(), // Object ID
         ByteVector.fromULong(30 + childrenBytes.length, false), // Object size
-        ByteVector.fromUInt(children.length, false), // Child objects
+        ByteVector.fromUint(children.length, false), // Child objects
         0x01, 0x02, // Reserved bytes
         childrenBytes
     );
@@ -44,7 +44,7 @@ const getHeaderExtensionObject: (children: BaseObject[]) => HeaderExtensionObjec
         ByteVector.fromULong(46 + childrenBytes.length, false), // Object size
         Guids.AsfReserved1.toBytes(), // Reserved field 1
         ByteVector.fromUShort(6, false), // Reserved field 2
-        ByteVector.fromUInt(childrenBytes.length, false), // Header extension data length
+        ByteVector.fromUint(childrenBytes.length, false), // Header extension data length
         childrenBytes
     );
     const headerExtFile = TestFile.getFile(headerExtBytes);
@@ -1061,7 +1061,7 @@ const getTagWithExtensionDescriptor: (descriptorName: string, descriptorType: Da
         const pic2PictureData = ByteVector.fromSize(10, 0x08);
         const pic2Data = ByteVector.concatenate(
             PictureType.ColoredFish,
-            ByteVector.fromUInt(pic2PictureData.length, false),
+            ByteVector.fromUint(pic2PictureData.length, false),
             ByteVector.fromString("Ha! Ha!", StringType.UTF16LE),
             ByteVector.getTextDelimiter(StringType.UTF16LE),
             ByteVector.fromString("I'm using the internet!", StringType.UTF16LE),
@@ -1406,7 +1406,7 @@ const getTagWithExtensionDescriptor: (descriptorName: string, descriptorType: Da
     public pictureFromData_missingMimeTypeDelimiter() {
         // Arrange
         const data = ByteVector.concatenate(
-            ByteVector.fromUInt(1234, false),
+            ByteVector.fromUint(1234, false),
             ByteVector.fromSize(10, 0x01)
         );
 
@@ -1421,7 +1421,7 @@ const getTagWithExtensionDescriptor: (descriptorName: string, descriptorType: Da
     public pictureFromData_missingMimeTypeDelimiterWithZeroes() {
         // Arrange
         const data = ByteVector.concatenate(
-            ByteVector.fromUInt(1234, false),
+            ByteVector.fromUint(1234, false),
             ByteVector.fromSize(10, 0x00)
         );
 
@@ -1436,7 +1436,7 @@ const getTagWithExtensionDescriptor: (descriptorName: string, descriptorType: Da
     public pictureFromData_missingDescriptionDelimiter() {
         // Arrange
         const data = ByteVector.concatenate(
-            ByteVector.fromUInt(1234, false),
+            ByteVector.fromUint(1234, false),
             ByteVector.fromString("Ha! Ha!", StringType.UTF16LE),
             ByteVector.getTextDelimiter(StringType.UTF16LE),
             ByteVector.fromSize(10, 0x01)
@@ -1453,7 +1453,7 @@ const getTagWithExtensionDescriptor: (descriptorName: string, descriptorType: Da
     public pictureFromData_missingDescriptionDelimiterWithZeroes() {
         // Arrange
         const data = ByteVector.concatenate(
-            ByteVector.fromUInt(1234, false),
+            ByteVector.fromUint(1234, false),
             ByteVector.fromString("Ha! Ha!", StringType.UTF16LE),
             ByteVector.getTextDelimiter(StringType.UTF16LE),
             ByteVector.fromSize(10, 0x00)
@@ -1472,7 +1472,7 @@ const getTagWithExtensionDescriptor: (descriptorName: string, descriptorType: Da
         const pictureData = ByteVector.fromSize(22, 0x08);
         const data = ByteVector.concatenate(
             PictureType.ColoredFish,
-            ByteVector.fromUInt(pictureData.length, false),
+            ByteVector.fromUint(pictureData.length, false),
             ByteVector.fromString("Ha! Ha!", StringType.UTF16LE),
             ByteVector.getTextDelimiter(StringType.UTF16LE),
             ByteVector.fromString("I'm using the internet!", StringType.UTF16LE),
@@ -1509,7 +1509,7 @@ const getTagWithExtensionDescriptor: (descriptorName: string, descriptorType: Da
         // Assert
         const expected = ByteVector.concatenate(
             PictureType.ColoredFish,
-            ByteVector.fromUInt(pictureData.length, false),
+            ByteVector.fromUint(pictureData.length, false),
             ByteVector.fromString("Ha! Ha!", StringType.UTF16LE),
             ByteVector.getTextDelimiter(StringType.UTF16LE),
             ByteVector.fromString("I'm using the internet!", StringType.UTF16LE),

--- a/test-unit/asf/extendedContentDescriptionObjectTests.ts
+++ b/test-unit/asf/extendedContentDescriptionObjectTests.ts
@@ -76,7 +76,7 @@ const assert = Chai.assert;
             ByteVector.fromString("foo\0", StringType.UTF16LE),
             ByteVector.fromUShort(DataType.Bool, false),
             ByteVector.fromUShort(4, false),
-            ByteVector.fromUInt(1, false)
+            ByteVector.fromUint(1, false)
         );
         Testers.bvEqual(object.render(), expectedBytes);
     }
@@ -89,7 +89,7 @@ const assert = Chai.assert;
             ByteVector.fromString("foo\0", StringType.UTF16LE),
             ByteVector.fromUShort(DataType.Bool, false),
             ByteVector.fromUShort(4, false),
-            ByteVector.fromUInt(1, false)
+            ByteVector.fromUint(1, false)
         );
         const file = TestFile.getFile(bytes);
 
@@ -117,7 +117,7 @@ const assert = Chai.assert;
             ByteVector.fromString("foo\0", StringType.UTF16LE),
             ByteVector.fromUShort(DataType.DWord, false),
             ByteVector.fromUShort(4, false),
-            ByteVector.fromUInt(1234, false)
+            ByteVector.fromUint(1234, false)
         );
         Testers.bvEqual(object.render(), expectedBytes);
     }
@@ -130,7 +130,7 @@ const assert = Chai.assert;
             ByteVector.fromString("foo\0", StringType.UTF16LE),
             ByteVector.fromUShort(DataType.DWord, false),
             ByteVector.fromUShort(4, false),
-            ByteVector.fromUInt(1234, false)
+            ByteVector.fromUint(1234, false)
         );
         const file = TestFile.getFile(bytes);
 

--- a/test-unit/asf/filePropertiesObjectTests.ts
+++ b/test-unit/asf/filePropertiesObjectTests.ts
@@ -36,10 +36,10 @@ class Asf_FilePropertiesObjectTests extends ObjectTests<FilePropertiesObject> {
             ByteVector.fromULong(345600, false), // Play duration
             ByteVector.fromULong(456700, false), // Send duration
             ByteVector.fromULong(5678, false), // Preroll
-            ByteVector.fromUInt(123, false), // Flags
-            ByteVector.fromUInt(234, false), // Minimum data packet size
-            ByteVector.fromUInt(345, false), // Maximum data packet size
-            ByteVector.fromUInt(456, false) // Maximum bitrate
+            ByteVector.fromUint(123, false), // Flags
+            ByteVector.fromUint(234, false), // Minimum data packet size
+            ByteVector.fromUint(345, false), // Maximum data packet size
+            ByteVector.fromUint(456, false) // Maximum bitrate
         );
         const file = TestFile.getFile(data);
 
@@ -79,10 +79,10 @@ class Asf_FilePropertiesObjectTests extends ObjectTests<FilePropertiesObject> {
             ByteVector.fromULong(345600, false), // Play duration
             ByteVector.fromULong(456700, false), // Send duration
             ByteVector.fromULong(567800, false), // Preroll
-            ByteVector.fromUInt(123, false), // Flags
-            ByteVector.fromUInt(234, false), // Minimum data packet size
-            ByteVector.fromUInt(345, false), // Maximum data packet size
-            ByteVector.fromUInt(456, false) // Maximum bitrate
+            ByteVector.fromUint(123, false), // Flags
+            ByteVector.fromUint(234, false), // Minimum data packet size
+            ByteVector.fromUint(345, false), // Maximum data packet size
+            ByteVector.fromUint(456, false) // Maximum bitrate
         );
         const file = TestFile.getFile(data);
         const object = FilePropertiesObject.fromFile(file, 10);

--- a/test-unit/asf/headerExtensionObjectTests.ts
+++ b/test-unit/asf/headerExtensionObjectTests.ts
@@ -33,7 +33,7 @@ const assert = Chai.assert;
             ByteVector.fromULong(56, false), // Object size
             new UuidWrapper().toBytes(), // Invalid reserved field 1
             ByteVector.fromUShort(6, false), // Reserved field 2
-            ByteVector.fromUInt(10, false), // Header extension data length
+            ByteVector.fromUint(10, false), // Header extension data length
             ByteVector.fromSize(10), // Header extension data
         );
         const file = TestFile.getFile(data);
@@ -51,7 +51,7 @@ const assert = Chai.assert;
             ByteVector.fromULong(56, false), // Object size
             Guids.AsfReserved1.toBytes(), // Reserved field 1
             ByteVector.fromUShort(8888, false), // Invalid reserved field 2
-            ByteVector.fromUInt(10, false), // Header extension data length
+            ByteVector.fromUint(10, false), // Header extension data length
             ByteVector.fromSize(10), // Header extension data
         );
         const file = TestFile.getFile(data);
@@ -168,7 +168,7 @@ const assert = Chai.assert;
             ByteVector.fromULong(46 + childrenBytes.length, false), // Object size
             Guids.AsfReserved1.toBytes(), // Reserved field 1
             ByteVector.fromUShort(6, false), // Reserved field 2
-            ByteVector.fromUInt(childrenBytes.length, false), // Header extension data length
+            ByteVector.fromUint(childrenBytes.length, false), // Header extension data length
             childrenBytes
         );
     }

--- a/test-unit/asf/headerObjectTests.ts
+++ b/test-unit/asf/headerObjectTests.ts
@@ -32,7 +32,7 @@ const assert = Chai.assert;
             ByteVector.fromSize(10), // Offset
             Guids.AsfHeaderObject.toBytes(), // Object ID
             ByteVector.fromULong(30, false), // Object size
-            ByteVector.fromUInt(0, false), // Child objects
+            ByteVector.fromUint(0, false), // Child objects
             0x12, 0x02 // Invalid reserved
         );
         const file = TestFile.getFile(bytes);
@@ -48,7 +48,7 @@ const assert = Chai.assert;
             ByteVector.fromSize(10), // Offset
             Guids.AsfHeaderObject.toBytes(), // Object ID
             ByteVector.fromULong(30, false), // Object size
-            ByteVector.fromUInt(0, false), // Child objects
+            ByteVector.fromUint(0, false), // Child objects
             0x01, 0x23 // Invalid reserved
         );
         const file = TestFile.getFile(bytes);
@@ -95,7 +95,7 @@ const assert = Chai.assert;
             ByteVector.fromULong(46, false), // Object size
             Guids.AsfReserved1.toBytes(), // Reserved field 1
             ByteVector.fromUShort(6, false), // Reserved field 2
-            ByteVector.fromUInt(0, false), // Header extension data length
+            ByteVector.fromUint(0, false), // Header extension data length
         );
 
         const headerBytes = Asf_HeaderObjectTests.getObjectBytesFromBytes(headerExtensionBytes, 1);
@@ -169,10 +169,10 @@ const assert = Chai.assert;
             ByteVector.fromULong(3456000, false), // Play duration
             ByteVector.fromULong(4567000, false), // Send duration
             ByteVector.fromULong(5, false), // Preroll
-            ByteVector.fromUInt(123, false), // Flags
-            ByteVector.fromUInt(234, false), // Minimum data packet size
-            ByteVector.fromUInt(345, false), // Maximum data packet size
-            ByteVector.fromUInt(456, false) // Maximum bitrate
+            ByteVector.fromUint(123, false), // Flags
+            ByteVector.fromUint(234, false), // Minimum data packet size
+            ByteVector.fromUint(345, false), // Maximum data packet size
+            ByteVector.fromUint(456, false) // Maximum bitrate
         );
 
         const streamPropertiesBytes = ByteVector.concatenate(
@@ -181,15 +181,15 @@ const assert = Chai.assert;
             Guids.AsfAudioMedia.toBytes(), // Stream type
             new UuidWrapper().toBytes(), // Error correction type GUID
             ByteVector.fromULong(1234567890, false), // Time offset
-            ByteVector.fromUInt(16, false), // Type specific data length
-            ByteVector.fromUInt(23, false), // Error correction data length
+            ByteVector.fromUint(16, false), // Type specific data length
+            ByteVector.fromUint(23, false), // Error correction data length
             ByteVector.fromShort(0x1200, false), // Flags
             ByteVector.fromSize(4, 0x0), // Reserved
             // AUDIO TYPE SPECIFIC DATA
             ByteVector.fromUShort(0xF1AC, false), // Format tag
             ByteVector.fromUShort(3, false), // Number of channels
-            ByteVector.fromUInt(1234, false), // Samples per second
-            ByteVector.fromUInt(2345, false), // Average bytes per second
+            ByteVector.fromUint(1234, false), // Samples per second
+            ByteVector.fromUint(2345, false), // Average bytes per second
             ByteVector.fromUShort(88, false), // Block align
             ByteVector.fromUShort(16, false), // Bits per sample
             ByteVector.fromSize(23, 0x23)
@@ -347,7 +347,7 @@ const assert = Chai.assert;
             ByteVector.fromSize(10), // Offset
             Guids.AsfHeaderObject.toBytes(), // Object ID
             ByteVector.fromULong(30 + children.length, false), // Object size
-            ByteVector.fromUInt(childrenCount, false), // Child objects
+            ByteVector.fromUint(childrenCount, false), // Child objects
             0x01, 0x02, // Invalid reserved
             children
         );
@@ -359,7 +359,7 @@ const assert = Chai.assert;
             ByteVector.fromSize(10), // Offset
             Guids.AsfHeaderObject.toBytes(), // Object ID
             ByteVector.fromULong(30 + childrenBytes.length, false), // Object size
-            ByteVector.fromUInt(children.length, false), // Child objects
+            ByteVector.fromUint(children.length, false), // Child objects
             0x01, 0x02, // Reserved bytes
             childrenBytes
         );

--- a/test-unit/asf/metadataLibraryObjectTests.ts
+++ b/test-unit/asf/metadataLibraryObjectTests.ts
@@ -42,7 +42,7 @@ const assert = Chai.assert;
             ByteVector.fromUShort(234, false),
             ByteVector.fromUShort(8, false),
             ByteVector.fromUShort(DataType.Word, false),
-            ByteVector.fromUInt(2, false),
+            ByteVector.fromUint(2, false),
             ByteVector.fromString("foo\0", StringType.UTF16LE),
             ByteVector.fromUShort(1234, false)
         );
@@ -57,7 +57,7 @@ const assert = Chai.assert;
             ByteVector.fromUShort(234, false),
             ByteVector.fromUShort(8, false),
             ByteVector.fromUShort(DataType.Word, false),
-            ByteVector.fromUInt(2, false),
+            ByteVector.fromUint(2, false),
             ByteVector.fromString("foo\0", StringType.UTF16LE),
             ByteVector.fromUShort(1234, false)
         );
@@ -92,7 +92,7 @@ const assert = Chai.assert;
             ByteVector.fromUShort(234, false),
             ByteVector.fromUShort(8, false),
             ByteVector.fromUShort(DataType.Bool, false),
-            ByteVector.fromUInt(2, false),
+            ByteVector.fromUint(2, false),
             ByteVector.fromString("foo\0", StringType.UTF16LE),
             ByteVector.fromUShort(1, false)
         );
@@ -107,7 +107,7 @@ const assert = Chai.assert;
             ByteVector.fromUShort(234, false),
             ByteVector.fromUShort(8, false),
             ByteVector.fromUShort(DataType.Bool, false),
-            ByteVector.fromUInt(2, false),
+            ByteVector.fromUint(2, false),
             ByteVector.fromString("foo\0", StringType.UTF16LE),
             ByteVector.fromUShort(1, false)
         );
@@ -133,9 +133,9 @@ const assert = Chai.assert;
             ByteVector.fromUShort(234, false),
             ByteVector.fromUShort(8, false),
             ByteVector.fromUShort(DataType.Bool, false),
-            ByteVector.fromUInt(4, false),
+            ByteVector.fromUint(4, false),
             ByteVector.fromString("foo\0", StringType.UTF16LE),
-            ByteVector.fromUInt(0, false)
+            ByteVector.fromUint(0, false)
         );
         const file = TestFile.getFile(bytes);
 
@@ -169,9 +169,9 @@ const assert = Chai.assert;
             ByteVector.fromUShort(234, false),
             ByteVector.fromUShort(8, false),
             ByteVector.fromUShort(DataType.DWord, false),
-            ByteVector.fromUInt(4, false),
+            ByteVector.fromUint(4, false),
             ByteVector.fromString("foo\0", StringType.UTF16LE),
-            ByteVector.fromUInt(1234, false)
+            ByteVector.fromUint(1234, false)
         );
         Testers.bvEqual(object.render(), expectedBytes);
     }
@@ -184,9 +184,9 @@ const assert = Chai.assert;
             ByteVector.fromUShort(234, false),
             ByteVector.fromUShort(8, false),
             ByteVector.fromUShort(DataType.DWord, false),
-            ByteVector.fromUInt(4, false),
+            ByteVector.fromUint(4, false),
             ByteVector.fromString("foo\0", StringType.UTF16LE),
-            ByteVector.fromUInt(1234, false)
+            ByteVector.fromUint(1234, false)
         );
         const file = TestFile.getFile(bytes);
 
@@ -220,7 +220,7 @@ const assert = Chai.assert;
             ByteVector.fromUShort(234, false),
             ByteVector.fromUShort(8, false),
             ByteVector.fromUShort(DataType.QWord, false),
-            ByteVector.fromUInt(8, false),
+            ByteVector.fromUint(8, false),
             ByteVector.fromString("foo\0", StringType.UTF16LE),
             ByteVector.fromULong(1234, false)
         );
@@ -235,7 +235,7 @@ const assert = Chai.assert;
             ByteVector.fromUShort(234, false),
             ByteVector.fromUShort(8, false),
             ByteVector.fromUShort(DataType.QWord, false),
-            ByteVector.fromUInt(8, false),
+            ByteVector.fromUint(8, false),
             ByteVector.fromString("foo\0", StringType.UTF16LE),
             ByteVector.fromULong(1234, false)
         );
@@ -271,7 +271,7 @@ const assert = Chai.assert;
             ByteVector.fromUShort(234, false),
             ByteVector.fromUShort(8, false),
             ByteVector.fromUShort(DataType.Unicode, false),
-            ByteVector.fromUInt(20, false),
+            ByteVector.fromUint(20, false),
             ByteVector.fromString("foo\0", StringType.UTF16LE),
             ByteVector.fromString("foobarbaz\0", StringType.UTF16LE)
         );
@@ -286,7 +286,7 @@ const assert = Chai.assert;
             ByteVector.fromUShort(234, false),
             ByteVector.fromUShort(8, false),
             ByteVector.fromUShort(DataType.Unicode, false),
-            ByteVector.fromUInt(20, false),
+            ByteVector.fromUint(20, false),
             ByteVector.fromString("foo\0", StringType.UTF16LE),
             ByteVector.fromString("foobarbaz\0", StringType.UTF16LE)
         );
@@ -325,7 +325,7 @@ const assert = Chai.assert;
             ByteVector.fromUShort(234, false),
             ByteVector.fromUShort(8, false),
             ByteVector.fromUShort(DataType.Bytes, false),
-            ByteVector.fromUInt(6, false),
+            ByteVector.fromUint(6, false),
             ByteVector.fromString("foo\0", StringType.UTF16LE),
             bytes
         );
@@ -343,7 +343,7 @@ const assert = Chai.assert;
             ByteVector.fromUShort(234, false),
             ByteVector.fromUShort(8, false),
             ByteVector.fromUShort(DataType.Bytes, false),
-            ByteVector.fromUInt(6, false),
+            ByteVector.fromUint(6, false),
             ByteVector.fromString("foo\0", StringType.UTF16LE),
             bytes
         );
@@ -382,7 +382,7 @@ const assert = Chai.assert;
             ByteVector.fromUShort(234, false),
             ByteVector.fromUShort(8, false),
             ByteVector.fromUShort(DataType.Guid, false),
-            ByteVector.fromUInt(16, false),
+            ByteVector.fromUint(16, false),
             ByteVector.fromString("foo\0", StringType.UTF16LE),
             guid.toBytes()
         );
@@ -400,7 +400,7 @@ const assert = Chai.assert;
             ByteVector.fromUShort(234, false),
             ByteVector.fromUShort(8, false),
             ByteVector.fromUShort(DataType.Guid, false),
-            ByteVector.fromUInt(16, false),
+            ByteVector.fromUint(16, false),
             ByteVector.fromString("foo\0", StringType.UTF16LE),
             guid.toBytes()
         );

--- a/test-unit/asf/streamPropertiesObjectTests.ts
+++ b/test-unit/asf/streamPropertiesObjectTests.ts
@@ -73,15 +73,15 @@ const assert = Chai.assert;
             Guids.AsfAudioMedia.toBytes(), // Stream type
             this._errorCorrectionGuid.toBytes(), // Error correction type GUID
             ByteVector.fromULong(this._timeOffset, false), // Time offset
-            ByteVector.fromUInt(16, false), // Type specific data length
-            ByteVector.fromUInt(this._errorCorrectionData.length, false), // Error correction data length
+            ByteVector.fromUint(16, false), // Type specific data length
+            ByteVector.fromUint(this._errorCorrectionData.length, false), // Error correction data length
             ByteVector.fromShort(this._flags, false), // Flags
             ByteVector.fromSize(4, 0x0), // Reserved
             // AUDIO TYPE SPECIFIC DATA
             ByteVector.fromUShort(0xF1AC, false), // Format tag
             ByteVector.fromUShort(3, false), // Number of channels
-            ByteVector.fromUInt(1234, false), // Samples per second
-            ByteVector.fromUInt(2345, false), // Average bytes per second
+            ByteVector.fromUint(1234, false), // Samples per second
+            ByteVector.fromUint(2345, false), // Average bytes per second
             ByteVector.fromUShort(88, false), // Block align
             ByteVector.fromUShort(16, false), // Bits per sample
             this._errorCorrectionData
@@ -107,23 +107,23 @@ const assert = Chai.assert;
             Guids.AsfVideoMedia.toBytes(), // Stream type
             this._errorCorrectionGuid.toBytes(), // Error correction type GUID
             ByteVector.fromULong(this._timeOffset, false), // Time offset
-            ByteVector.fromUInt(51, false), // Type specific data length
-            ByteVector.fromUInt(this._errorCorrectionData.length, false), // Error correction data length
+            ByteVector.fromUint(51, false), // Type specific data length
+            ByteVector.fromUint(this._errorCorrectionData.length, false), // Error correction data length
             ByteVector.fromShort(this._flags, false), // Flags
             ByteVector.fromSize(4, 0x0), // Reserved
             // VIDEO TYPE SPECIFIC DATA
             ByteVector.fromSize(11), // Offset (ASF summary of video specific data)
-            ByteVector.fromUInt(40, false), // Size of the struct
-            ByteVector.fromUInt(123, false), // Width of image
-            ByteVector.fromUInt(234, false), // Height of image
+            ByteVector.fromUint(40, false), // Size of the struct
+            ByteVector.fromUint(123, false), // Width of image
+            ByteVector.fromUint(234, false), // Height of image
             ByteVector.fromUShort(345, false), // Number of planes
             ByteVector.fromUShort(456, false), // Average bits per pixel
-            ByteVector.fromUInt(0x58564944, false), // FOURCC [DIVX]
-            ByteVector.fromUInt(567, false), // Size of the image
-            ByteVector.fromUInt(678, false), // Pixels per meter X
-            ByteVector.fromUInt(789, false), // Pixels per meter Y
-            ByteVector.fromUInt(890, false), // Colors used
-            ByteVector.fromUInt(1234, false), // Important colors
+            ByteVector.fromUint(0x58564944, false), // FOURCC [DIVX]
+            ByteVector.fromUint(567, false), // Size of the image
+            ByteVector.fromUint(678, false), // Pixels per meter X
+            ByteVector.fromUint(789, false), // Pixels per meter Y
+            ByteVector.fromUint(890, false), // Colors used
+            ByteVector.fromUint(1234, false), // Important colors
             this._errorCorrectionData
         );
         const file = TestFile.getFile(bytes);
@@ -156,8 +156,8 @@ const assert = Chai.assert;
             this._streamTypeGuid.toBytes(), // Stream type
             this._errorCorrectionGuid.toBytes(), // Error correction type GUID
             ByteVector.fromULong(this._timeOffset, false), // Time offset
-            ByteVector.fromUInt(this._typeSpecificData.length, false), // Type specific data length
-            ByteVector.fromUInt(this._errorCorrectionData.length, false), // Error correction data length
+            ByteVector.fromUint(this._typeSpecificData.length, false), // Type specific data length
+            ByteVector.fromUint(this._errorCorrectionData.length, false), // Error correction data length
             ByteVector.fromShort(this._flags, false), // Flags
             ByteVector.fromSize(4, 0x0), // Reserved
             this._typeSpecificData,

--- a/test-unit/byteVectorConstructorTests.ts
+++ b/test-unit/byteVectorConstructorTests.ts
@@ -1356,13 +1356,13 @@ const assert = Chai.assert;
     @test
     public fromUInt_badInteger() {
         // Arrange, Act, Assert
-        Testers.testUint((v: number) => { ByteVector.fromUInt(v); });
+        Testers.testUint((v: number) => { ByteVector.fromUint(v); });
     }
 
     @test
     public fromUInt_overflow() {
         // Arrange, Act, Assert
-        assert.throws(() => { ByteVector.fromUInt(0x10000000000); });
+        assert.throws(() => { ByteVector.fromUint(0x10000000000); });
     }
 
     @test
@@ -2043,7 +2043,7 @@ const assert = Chai.assert;
 
     private static testUInt(value: number, expectedData: number[], isReadOnly: boolean, bigEndian: boolean): void {
         // Arrange, Act
-        const bv = ByteVector.fromUInt(value, bigEndian, isReadOnly);
+        const bv = ByteVector.fromUint(value, bigEndian, isReadOnly);
 
         // Assert
         assert.isOk(bv);

--- a/test-unit/byteVectorConversionTests.ts
+++ b/test-unit/byteVectorConversionTests.ts
@@ -680,49 +680,49 @@ const assert = Chai.assert;
 
     @test
     public toUInt_empty() {
-        const int = ByteVector.fromSize(0).toUInt();
+        const int = ByteVector.fromSize(0).toUint();
         assert.strictEqual(int, 0);
     }
 
     @test
     public toUInt_zero_complete() {
-        const int = ByteVector.fromByteArray(new Uint8Array([0x0, 0x0, 0x0, 0x0, 0xAA])).toUInt();
+        const int = ByteVector.fromByteArray(new Uint8Array([0x0, 0x0, 0x0, 0x0, 0xAA])).toUint();
         assert.strictEqual(int, 0);
     }
 
     @test
     public toUInt_zero_incomplete() {
-        const int = ByteVector.fromByteArray(new Uint8Array([0x0, 0x0])).toUInt();
+        const int = ByteVector.fromByteArray(new Uint8Array([0x0, 0x0])).toUint();
         assert.strictEqual(int, 0);
     }
 
     @test
     public toUInt_positiveBigEndian_complete() {
-        const int = this.uintPositiveCompleteBV.toUInt();
+        const int = this.uintPositiveCompleteBV.toUint();
         assert.strictEqual(int, 0x01020304);
     }
 
     @test
     public toUInt_positiveBigEndian_incomplete() {
-        const int = this.uintPositiveIncompleteBV.toUInt();
+        const int = this.uintPositiveIncompleteBV.toUint();
         assert.strictEqual(int, 0x00000102);
     }
 
     @test
     public toUInt_positiveLittleEndian_complete() {
-        const int = this.uintPositiveCompleteBV.toUInt(false);
+        const int = this.uintPositiveCompleteBV.toUint(false);
         assert.strictEqual(int, 0x04030201);
     }
 
     @test
     public toUInt_positiveLittleEndian_incomplete() {
-        const int = this.uintPositiveIncompleteBV.toUInt(false);
+        const int = this.uintPositiveIncompleteBV.toUint(false);
         assert.strictEqual(int, 0x00000201);
     }
 
     @test
     public toUInt_unsignedRange_complete() {
-        const int = ByteVector.fromByteArray(new Uint8Array([0xFF, 0xFF, 0xFF, 0xFF])).toUInt();
+        const int = ByteVector.fromByteArray(new Uint8Array([0xFF, 0xFF, 0xFF, 0xFF])).toUint();
         assert.strictEqual(int, 0xFFFFFFFF);
     }
 

--- a/test-unit/flac/flacBlockTests.ts
+++ b/test-unit/flac/flacBlockTests.ts
@@ -60,7 +60,7 @@ import {Testers} from "../utilities/testers";
         // Arrange
         const fileBytes = ByteVector.concatenate(
             ByteVector.fromSize(10),
-            ByteVector.fromUInt(0x86123456),
+            ByteVector.fromUint(0x86123456),
             ByteVector.fromSize(10)
         );
         const file = TestFile.getFile(fileBytes);
@@ -83,7 +83,7 @@ import {Testers} from "../utilities/testers";
         // Arrange
         const fileBytes = ByteVector.concatenate(
             ByteVector.fromSize(10),
-            ByteVector.fromUInt(0x06123456),
+            ByteVector.fromUint(0x06123456),
             ByteVector.fromSize(10)
         );
         const file = TestFile.getFile(fileBytes);
@@ -105,7 +105,7 @@ import {Testers} from "../utilities/testers";
     public fromFile_loadsOnDataAccess() {
         // Arrange
         const fileBytes = ByteVector.concatenate(
-            ByteVector.fromUInt(0x0600000A),
+            ByteVector.fromUint(0x0600000A),
             ByteVector.fromSize(10, 0x0B)
         );
         const file = TestFile.getFile(fileBytes);

--- a/test-unit/flac/flacFileTests.ts
+++ b/test-unit/flac/flacFileTests.ts
@@ -44,12 +44,12 @@ import {Picture} from "../../src";
             FlacFileSettings.defaultTagTypes = TagTypes.Id3v2 | TagTypes.Ape;
 
             // Arrange
-            const id3v2Tag = this.getId3v2Tag(false);
-            const apeTag = this.getApeTag();
+            const id3v2Tag = Flac_File_ConstructorTests.getId3v2Tag(false);
+            const apeTag = Flac_File_ConstructorTests.getApeTag();
             const tagBytes = ByteVector.concatenate(id3v2Tag.render(), apeTag.render());
             const fileBytes = ByteVector.concatenate(
                 tagBytes,
-                this.getBasicFile()
+                Flac_File_ConstructorTests.getBasicFile()
             );
             const testAbstraction = TestFile.getFileAbstraction(fileBytes);
 
@@ -62,7 +62,7 @@ import {Picture} from "../../src";
             assert.strictEqual(file.mediaStartPosition, tagBytes.length);
             assert.strictEqual(file.mediaEndPosition, fileBytes.length);
 
-            this.assertTags(file, TagTypes.Ape | TagTypes.Id3v2, TagTypes.None, false);
+            Flac_File_ConstructorTests.assertTags(file, TagTypes.Ape | TagTypes.Id3v2, TagTypes.None, false);
             this.assertApeTag(file);
             this.assertId3v2Tag(file);
 
@@ -81,12 +81,12 @@ import {Picture} from "../../src";
             FlacFileSettings.defaultTagTypes = TagTypes.Id3v1 | TagTypes.Id3v1 | TagTypes.Ape;
 
             // Arrange
-            const id3v2Tag = this.getId3v2Tag(true);
-            const apeTag = this.getApeTag();
-            const id3v1Tag = this.getId3v1Tag();
+            const id3v2Tag = Flac_File_ConstructorTests.getId3v2Tag(true);
+            const apeTag = Flac_File_ConstructorTests.getApeTag();
+            const id3v1Tag = Flac_File_ConstructorTests.getId3v1Tag();
             const tagBytes = ByteVector.concatenate(id3v2Tag.render(), apeTag.render(), id3v1Tag.render());
             const fileBytes = ByteVector.concatenate(
-                this.getBasicFile(),
+                Flac_File_ConstructorTests.getBasicFile(),
                 tagBytes
             );
             const testAbstraction = TestFile.getFileAbstraction(fileBytes);
@@ -100,7 +100,10 @@ import {Picture} from "../../src";
             assert.strictEqual(file.mediaStartPosition, 0);
             assert.strictEqual(file.mediaEndPosition, fileBytes.length - tagBytes.length);
 
-            this.assertTags(file, TagTypes.None, TagTypes.Id3v1 | TagTypes.Id3v2 | TagTypes.Ape, false);
+            Flac_File_ConstructorTests.assertTags(
+                file,
+                TagTypes.None, TagTypes.Id3v1 | TagTypes.Id3v2 | TagTypes.Ape,
+                false);
             this.assertApeTag(file);
             this.assertId3v1Tag(file);
             this.assertId3v2Tag(file);
@@ -120,9 +123,9 @@ import {Picture} from "../../src";
             FlacFileSettings.defaultTagTypes = TagTypes.Xiph;
 
             // Arrange
-            const xiphTag = this.getXiphTag();
+            const xiphTag = Flac_File_ConstructorTests.getXiphTag();
             const xiphBlock = FlacBlock.fromData(FlacBlockType.XiphComment, xiphTag.render(false));
-            const fileBytes = this.getBasicFile([xiphBlock]);
+            const fileBytes = Flac_File_ConstructorTests.getBasicFile([xiphBlock]);
             const testAbstraction = TestFile.getFileAbstraction(fileBytes);
 
             // Act
@@ -134,8 +137,8 @@ import {Picture} from "../../src";
             assert.strictEqual(file.mediaStartPosition, 0);
             assert.strictEqual(file.mediaEndPosition, testAbstraction.allBytes.length);
 
-            this.assertTags(file, TagTypes.None, TagTypes.None, true);
-            this.assertXiphTag(file);
+            Flac_File_ConstructorTests.assertTags(file, TagTypes.None, TagTypes.None, true);
+            Flac_File_ConstructorTests.assertXiphTag(file);
 
             assert.strictEqual(file.tagTypes, TagTypes.Xiph);
             assert.strictEqual(file.tagTypes, TagTypes.Xiph);
@@ -159,7 +162,7 @@ import {Picture} from "../../src";
             xiphTag2.title = "Mobile";
             const xiph2Block = FlacBlock.fromData(FlacBlockType.XiphComment, xiphTag2.render(false));
 
-            const fileBytes = this.getBasicFile([xiph1Block, xiph2Block]);
+            const fileBytes = Flac_File_ConstructorTests.getBasicFile([xiph1Block, xiph2Block]);
             const testAbstraction = TestFile.getFileAbstraction(fileBytes);
 
             // Act
@@ -171,7 +174,7 @@ import {Picture} from "../../src";
             assert.strictEqual(file.mediaStartPosition, 0);
             assert.strictEqual(file.mediaEndPosition, testAbstraction.allBytes.length);
 
-            this.assertTags(file, TagTypes.None, TagTypes.None, true);
+            Flac_File_ConstructorTests.assertTags(file, TagTypes.None, TagTypes.None, true);
             const xiphTag = file.tag.xiphComment;
             assert.isOk(xiphTag);
             assert.strictEqual(xiphTag.album, "Ascend EP");
@@ -192,12 +195,12 @@ import {Picture} from "../../src";
 
             // Arrange
             const extraBlocks = [
-                this.getPictureBlock(),
+                Flac_File_ConstructorTests.getPictureBlock(),
                 FlacBlock.fromData(FlacBlockType.Padding, ByteVector.fromSize(10)),
-                this.getPictureBlock()
+                Flac_File_ConstructorTests.getPictureBlock()
             ];
 
-            const fileBytes = this.getBasicFile(extraBlocks);
+            const fileBytes = Flac_File_ConstructorTests.getBasicFile(extraBlocks);
             const testAbstraction = TestFile.getFileAbstraction(fileBytes);
 
             // Act
@@ -209,7 +212,7 @@ import {Picture} from "../../src";
             assert.strictEqual(file.mediaStartPosition, 0);
             assert.strictEqual(file.mediaEndPosition, testAbstraction.allBytes.length);
 
-            this.assertTags(file, TagTypes.None, TagTypes.None, false);
+            Flac_File_ConstructorTests.assertTags(file, TagTypes.None, TagTypes.None, false);
             assert.strictEqual(file.tag.pictures.length, 2);
 
             assert.strictEqual(file.tagTypes, TagTypes.FlacPictures);
@@ -226,11 +229,11 @@ import {Picture} from "../../src";
             FlacFileSettings.defaultTagTypes = TagTypes.None;
 
             // Arrange
-            const id3v2Tag = this.getId3v2Tag(false);
-            const apeTag = this.getApeTag();
-            const id3v1Tag = this.getId3v1Tag();
-            const xiphTag = this.getXiphTag();
-            const picBlock = this.getPictureBlock();
+            const id3v2Tag = Flac_File_ConstructorTests.getId3v2Tag(false);
+            const apeTag = Flac_File_ConstructorTests.getApeTag();
+            const id3v1Tag = Flac_File_ConstructorTests.getId3v1Tag();
+            const xiphTag = Flac_File_ConstructorTests.getXiphTag();
+            const picBlock = Flac_File_ConstructorTests.getPictureBlock();
             const extraBlocks = [
                 picBlock,
                 FlacBlock.fromData(FlacBlockType.Padding, ByteVector.fromSize(10)),
@@ -241,7 +244,7 @@ import {Picture} from "../../src";
             const endTagBytes = id3v1Tag.render();
             const fileBytes = ByteVector.concatenate(
                 startTagBytes,
-                this.getBasicFile(extraBlocks),
+                Flac_File_ConstructorTests.getBasicFile(extraBlocks),
                 endTagBytes
             );
             const testAbstraction = TestFile.getFileAbstraction(fileBytes);
@@ -255,11 +258,11 @@ import {Picture} from "../../src";
             assert.strictEqual(file.mediaStartPosition, startTagBytes.length);
             assert.strictEqual(file.mediaEndPosition, fileBytes.length - endTagBytes.length);
 
-            this.assertTags(file, TagTypes.Id3v2 | TagTypes.Ape, TagTypes.Id3v1, true);
+            Flac_File_ConstructorTests.assertTags(file, TagTypes.Id3v2 | TagTypes.Ape, TagTypes.Id3v1, true);
             this.assertId3v1Tag(file);
             this.assertId3v2Tag(file);
             this.assertApeTag(file);
-            this.assertXiphTag(file);
+            Flac_File_ConstructorTests.assertXiphTag(file);
             assert.strictEqual(file.tag.pictures.length, 1);
 
             const expectedTags = TagTypes.FlacPictures | TagTypes.Xiph | TagTypes.Id3v1 | TagTypes.Id3v2 | TagTypes.Ape;
@@ -288,7 +291,7 @@ import {Picture} from "../../src";
     @test
     public constructor_averageRead_hasStreamInfo() {
         // Arrange
-        const fileBytes = this.getBasicFile();
+        const fileBytes = Flac_File_ConstructorTests.getBasicFile();
         const testAbstraction = TestFile.getFileAbstraction(fileBytes);
 
         // Act
@@ -311,7 +314,7 @@ import {Picture} from "../../src";
         // Arrange
         const originalDefaults = FlacFileSettings.defaultTagTypes;
         try {
-            const testAbstraction = TestFile.getFileAbstraction(this.getBasicFile());
+            const testAbstraction = TestFile.getFileAbstraction(Flac_File_ConstructorTests.getBasicFile());
 
             // Act
             FlacFileSettings.defaultTagTypes = TagTypes.None;
@@ -335,7 +338,7 @@ import {Picture} from "../../src";
         const originalApeLocation = FlacFileSettings.preferApeTagAtFileEnd;
         const originalId3v2Location = FlacFileSettings.preferId3v2TagAtFileEnd;
         try {
-            const fileBytes = this.getBasicFile();
+            const fileBytes = Flac_File_ConstructorTests.getBasicFile();
             const testAbstraction = TestFile.getFileAbstraction(fileBytes);
 
             // Act
@@ -370,7 +373,7 @@ import {Picture} from "../../src";
         const originalApeLocation = FlacFileSettings.preferApeTagAtFileEnd;
         const originalId3v2Location = FlacFileSettings.preferId3v2TagAtFileEnd;
         try {
-            const fileBytes = this.getBasicFile();
+            const fileBytes = Flac_File_ConstructorTests.getBasicFile();
             const testAbstraction = TestFile.getFileAbstraction(fileBytes);
 
             // Act
@@ -403,7 +406,7 @@ import {Picture} from "../../src";
         // Arrange
         const originalDefaults = FlacFileSettings.defaultTagTypes;
         try {
-            const fileBytes = this.getBasicFile();
+            const fileBytes = Flac_File_ConstructorTests.getBasicFile();
             const testAbstraction = TestFile.getFileAbstraction(fileBytes);
 
             // Act
@@ -429,7 +432,7 @@ import {Picture} from "../../src";
     @test
     public getTag_tagExists() {
         // Arrange
-        const fileBytes = this.getCompleteFile();
+        const fileBytes = Flac_File_ConstructorTests.getCompleteFile();
         const testAbstraction = TestFile.getFileAbstraction(fileBytes);
         const file = new FlacFile(testAbstraction, ReadStyle.None);
 
@@ -442,7 +445,7 @@ import {Picture} from "../../src";
 
     @test
     public getTag_id3v1TagDoesNotExist() {
-        this.getTagCreates(
+        Flac_File_ConstructorTests.getTagCreates(
             TagTypes.Id3v1,
             Id3v1Tag,
             () => false,
@@ -453,7 +456,7 @@ import {Picture} from "../../src";
 
     @test
     public getTag_id3v2TagDoesNotExistCreateAtFront() {
-        this.getTagCreates(
+        Flac_File_ConstructorTests.getTagCreates(
             TagTypes.Id3v2,
             Id3v2Tag,
             () => FlacFileSettings.preferId3v2TagAtFileEnd,
@@ -464,7 +467,7 @@ import {Picture} from "../../src";
 
     @test
     public getTag_id3v2TagDoesNotExistCreateAtEnd() {
-        this.getTagCreates(
+        Flac_File_ConstructorTests.getTagCreates(
             TagTypes.Id3v2,
             Id3v2Tag,
             () => FlacFileSettings.preferId3v2TagAtFileEnd,
@@ -475,7 +478,7 @@ import {Picture} from "../../src";
 
     @test
     public getTag_apeDoesNotExistCreateAtFront() {
-        this.getTagCreates(
+        Flac_File_ConstructorTests.getTagCreates(
             TagTypes.Ape,
             ApeTag,
             () => FlacFileSettings.preferApeTagAtFileEnd,
@@ -486,7 +489,7 @@ import {Picture} from "../../src";
 
     @test
     public getTag_apeDoesNotExistCreateAtEnd() {
-        this.getTagCreates(
+        Flac_File_ConstructorTests.getTagCreates(
             TagTypes.Ape,
             ApeTag,
             () => FlacFileSettings.preferApeTagAtFileEnd,
@@ -497,7 +500,7 @@ import {Picture} from "../../src";
 
     @test
     public getTag_xiphDoesNotExistCreates() {
-        this.getTagCreates(
+        Flac_File_ConstructorTests.getTagCreates(
             TagTypes.Xiph,
             XiphComment,
             () => false,
@@ -512,7 +515,7 @@ import {Picture} from "../../src";
         try {
             FlacFileSettings.defaultTagTypes = TagTypes.None;
 
-            const testAbstraction = TestFile.getFileAbstraction(this.getBasicFile());
+            const testAbstraction = TestFile.getFileAbstraction(Flac_File_ConstructorTests.getBasicFile());
             const file = new FlacFile(testAbstraction, ReadStyle.None);
 
             // Act
@@ -527,7 +530,7 @@ import {Picture} from "../../src";
         }
     }
 
-    private getTagCreates(
+    private static getTagCreates(
         tagType: TagTypes,
         // tslint:disable-next-line:ban-types It's the type that assert.instanceof uses
         instanceOf: Function,
@@ -542,7 +545,7 @@ import {Picture} from "../../src";
             FlacFileSettings.defaultTagTypes = TagTypes.None;
             locationSetter(createAtEnd);
 
-            const testAbstraction = TestFile.getFileAbstraction(this.getBasicFile());
+            const testAbstraction = TestFile.getFileAbstraction(Flac_File_ConstructorTests.getBasicFile());
             const file = new FlacFile(testAbstraction, ReadStyle.None);
 
             // Act
@@ -571,7 +574,7 @@ import {Picture} from "../../src";
     @test
     public removeTags() {
         // Arrange
-        const fileBytes = this.getCompleteFile();
+        const fileBytes = Flac_File_ConstructorTests.getCompleteFile();
         const testAbstraction = TestFile.getFileAbstraction(fileBytes);
         const file = new FlacFile(testAbstraction, ReadStyle.None);
         const originalTagTypes = file.tagTypes;
@@ -588,7 +591,7 @@ import {Picture} from "../../src";
     @test
     public save_noTagsOriginally_noTagsStored() {
         // Arrange
-        const fileBytes = this.getBasicFile();
+        const fileBytes = Flac_File_ConstructorTests.getBasicFile();
         const testAbstraction = TestFile.getFileAbstraction(fileBytes);
         const file = new FlacFile(testAbstraction, ReadStyle.None);
         file.removeTags(TagTypes.AllTags);
@@ -598,7 +601,7 @@ import {Picture} from "../../src";
 
         // Assert
         const paddingBlock = FlacBlock.fromData(FlacBlockType.Padding, ByteVector.fromSize(1024));
-        const expectedBytes = this.getBasicFile([paddingBlock]);
+        const expectedBytes = Flac_File_ConstructorTests.getBasicFile([paddingBlock]);
         Testers.bvEqual(testAbstraction.allBytes, expectedBytes);
 
         assert.strictEqual(file.mediaStartPosition, 0);
@@ -611,7 +614,7 @@ import {Picture} from "../../src";
     @test
     public save_noTagsOriginally_addTagsAtStart() {
         // Arrange
-        const fileBytes = this.getBasicFile();
+        const fileBytes = Flac_File_ConstructorTests.getBasicFile();
         const testAbstraction = TestFile.getFileAbstraction(fileBytes);
         const file = new FlacFile(testAbstraction, ReadStyle.None);
         file.removeTags(TagTypes.AllTags);
@@ -629,7 +632,7 @@ import {Picture} from "../../src";
         const startTagBytes = file.tag.startTag.render();
         const expectedBytes = ByteVector.concatenate(
             startTagBytes,
-            this.getBasicFile([paddingBlock])
+            Flac_File_ConstructorTests.getBasicFile([paddingBlock])
         );
         Testers.bvEqual(testAbstraction.allBytes, expectedBytes);
 
@@ -643,7 +646,7 @@ import {Picture} from "../../src";
     @test
     public save_noTagsOriginally_addTagsAtEnd() {
         // Arrange
-        const fileBytes = this.getBasicFile();
+        const fileBytes = Flac_File_ConstructorTests.getBasicFile();
         const testAbstraction = TestFile.getFileAbstraction(fileBytes);
         const file = new FlacFile(testAbstraction, ReadStyle.None);
         file.removeTags(TagTypes.AllTags);
@@ -662,7 +665,7 @@ import {Picture} from "../../src";
         const paddingBlock = FlacBlock.fromData(FlacBlockType.Padding, ByteVector.fromSize(1024));
         const endBytes = file.tag.endTag.render();
         const expectedBytes = ByteVector.concatenate(
-            this.getBasicFile([paddingBlock]),
+            Flac_File_ConstructorTests.getBasicFile([paddingBlock]),
             endBytes
         );
         Testers.bvEqual(testAbstraction.allBytes, expectedBytes);
@@ -677,7 +680,7 @@ import {Picture} from "../../src";
     @test
     public save_noTagsOriginally_addXiphAndPictures() {
         // Arrange
-        const fileBytes = this.getBasicFile();
+        const fileBytes = Flac_File_ConstructorTests.getBasicFile();
         const testAbstraction = TestFile.getFileAbstraction(fileBytes);
         const file = new FlacFile(testAbstraction, ReadStyle.None);
         file.removeTags(TagTypes.AllTags);
@@ -698,7 +701,7 @@ import {Picture} from "../../src";
         const picBlock1 = FlacBlock.fromData(FlacBlockType.Picture, XiphPicture.fromPicture(pic1).renderForFlacBlock());
         const picBlock2 = FlacBlock.fromData(FlacBlockType.Picture, XiphPicture.fromPicture(pic2).renderForFlacBlock());
         const xiphBlock = FlacBlock.fromData(FlacBlockType.XiphComment, xiphTag.render(false));
-        const expectedBytes = this.getBasicFile([xiphBlock, picBlock1, picBlock2, paddingBlock]);
+        const expectedBytes = Flac_File_ConstructorTests.getBasicFile([xiphBlock, picBlock1, picBlock2, paddingBlock]);
         Testers.bvEqual(testAbstraction.allBytes, expectedBytes);
 
         assert.strictEqual(file.mediaStartPosition, 0);
@@ -711,7 +714,7 @@ import {Picture} from "../../src";
     @test
     public save_hasTagsOriginally_newBlocksSmaller() {
         // Arrange
-        const fileBytes = this.getCompleteFile();
+        const fileBytes = Flac_File_ConstructorTests.getCompleteFile();
         const testAbstraction = TestFile.getFileAbstraction(fileBytes);
         const file = new FlacFile(testAbstraction, ReadStyle.None);
         file.removeTags(TagTypes.Xiph | TagTypes.FlacPictures);
@@ -721,15 +724,15 @@ import {Picture} from "../../src";
 
         // Assert
         const paddingLength = Flac_File_ConstructorTests.standardPadding
-            + this.getXiphTag().render(false).length + FlacBlock.headerSize
-            + this.getPictureBlock().render(false).length;
+            + Flac_File_ConstructorTests.getXiphTag().render(false).length + FlacBlock.headerSize
+            + Flac_File_ConstructorTests.getPictureBlock().render(false).length;
         const paddingBlock = FlacBlock.fromData(FlacBlockType.Padding, ByteVector.fromSize(paddingLength));
 
         const startTags = file.tag.startTag.render();
         const endTags = file.tag.endTag.render();
         const expectedBytes = ByteVector.concatenate(
             startTags,
-            this.getBasicFile([paddingBlock]),
+            Flac_File_ConstructorTests.getBasicFile([paddingBlock]),
             endTags
         );
         Testers.bvEqual(testAbstraction.allBytes, expectedBytes);
@@ -744,7 +747,7 @@ import {Picture} from "../../src";
     @test
     public save_hasTagsOriginally_newBlocksBigger() {
         // Arrange
-        const fileBytes = this.getCompleteFile();
+        const fileBytes = Flac_File_ConstructorTests.getCompleteFile();
         const testAbstraction = TestFile.getFileAbstraction(fileBytes);
         const file = new FlacFile(testAbstraction, ReadStyle.None);
 
@@ -760,9 +763,9 @@ import {Picture} from "../../src";
         const endTags = file.tag.endTag.render();
         const expectedBytes = ByteVector.concatenate(
             startTags,
-            this.getBasicFile([
+            Flac_File_ConstructorTests.getBasicFile([
                 FlacBlock.fromData(FlacBlockType.XiphComment, file.tag.xiphComment.render(false)),
-                this.getPictureBlock(),
+                Flac_File_ConstructorTests.getPictureBlock(),
                 FlacBlock.fromData(FlacBlockType.Picture, XiphPicture.fromPicture(newPicture).renderForFlacBlock()),
                 paddingBlock
             ]),
@@ -781,7 +784,7 @@ import {Picture} from "../../src";
     @test
     public save_hasTagsOriginally_newBlockBigger_savesAgain() {
         // Arrange
-        const fileBytes = this.getCompleteFile();
+        const fileBytes = Flac_File_ConstructorTests.getCompleteFile();
         const testAbstraction = TestFile.getFileAbstraction(fileBytes);
         const file = new FlacFile(testAbstraction, ReadStyle.None);
 
@@ -798,9 +801,9 @@ import {Picture} from "../../src";
         const endTags = file.tag.endTag.render();
         const expectedBytes = ByteVector.concatenate(
             startTags,
-            this.getBasicFile([
+            Flac_File_ConstructorTests.getBasicFile([
                 FlacBlock.fromData(FlacBlockType.XiphComment, file.tag.xiphComment.render(false)),
-                this.getPictureBlock(),
+                Flac_File_ConstructorTests.getPictureBlock(),
                 FlacBlock.fromData(FlacBlockType.Picture, XiphPicture.fromPicture(newPicture).renderForFlacBlock()),
                 paddingBlock
             ]),
@@ -819,7 +822,7 @@ import {Picture} from "../../src";
     // Helpers /////////////////////////////////////////////////////////////
     private static readonly standardPadding = 10;
 
-    private assertTags(file: FlacFile, startTags: TagTypes, endTags: TagTypes, xiph: boolean) {
+    private static assertTags(file: FlacFile, startTags: TagTypes, endTags: TagTypes, xiph: boolean) {
         assert.isOk(file.tag);
         assert.instanceOf(file.tag, FlacTag);
         assert.isOk(file.tag.startTag);
@@ -852,19 +855,19 @@ import {Picture} from "../../src";
         assert.strictEqual(id3v2Tag.title, "foo");
     }
 
-    private assertXiphTag(file: FlacFile) {
+    private static assertXiphTag(file: FlacFile) {
         const xiphTag = file.tag.xiphComment;
         assert.isOk(xiphTag);
         assert.strictEqual(xiphTag.amazonId, "foobarbaz");
     }
 
-    private getApeTag(): ApeTag {
+    private static getApeTag(): ApeTag {
         const apeTag = ApeTag.fromEmpty();
         apeTag.album = "bar";
         return apeTag;
     }
 
-    private getId3v2Tag(isAtEndOfFile: boolean): Id3v2Tag {
+    private static getId3v2Tag(isAtEndOfFile: boolean): Id3v2Tag {
         const id3v2Tag = Id3v2Tag.fromEmpty();
         id3v2Tag.version = 4;
         if (isAtEndOfFile) {
@@ -874,31 +877,31 @@ import {Picture} from "../../src";
         return id3v2Tag;
     }
 
-    private getId3v1Tag(): Id3v1Tag {
+    private static getId3v1Tag(): Id3v1Tag {
         const id3v1Tag = Id3v1Tag.fromEmpty();
         id3v1Tag.track = 123;
         return id3v1Tag;
     }
 
-    private getPictureBlock(): FlacBlock {
+    private static getPictureBlock(): FlacBlock {
         const picture = Picture.fromData(ByteVector.fromString("picturedata"));
         const flacPic = XiphPicture.fromPicture(picture);
         return FlacBlock.fromData(FlacBlockType.Picture, flacPic.renderForFlacBlock());
     }
 
-    private getXiphTag(): XiphComment {
+    private static getXiphTag(): XiphComment {
         const xiphTag = XiphComment.fromEmpty();
         xiphTag.amazonId = "foobarbaz";
         return xiphTag;
     }
 
-    private getBasicFile(extraBlocks?: FlacBlock[]): ByteVector {
+    private static getBasicFile(extraBlocks?: FlacBlock[]): ByteVector {
         const streamHeaderBytes = ByteVector.concatenate(
-            ByteVector.fromUInt(0x12345678),
-            ByteVector.fromUInt(0x23456789),
-            ByteVector.fromUInt(0x34567890),
-            ByteVector.fromUInt(0x45600000),
-            ByteVector.fromUInt(0x00009012)
+            ByteVector.fromUint(0x12345678),
+            ByteVector.fromUint(0x23456789),
+            ByteVector.fromUint(0x34567890),
+            ByteVector.fromUint(0x45600000),
+            ByteVector.fromUint(0x00009012)
         );
         const streamHeaderBlock = FlacBlock.fromData(FlacBlockType.StreamInfo, streamHeaderBytes);
 
@@ -910,12 +913,12 @@ import {Picture} from "../../src";
         );
     }
 
-    private getCompleteFile(): ByteVector {
-        const id3v2Tag = this.getId3v2Tag(false);
-        const apeTag = this.getApeTag();
-        const id3v1Tag = this.getId3v1Tag();
-        const xiphTag = this.getXiphTag();
-        const picBlock = this.getPictureBlock();
+    private static getCompleteFile(): ByteVector {
+        const id3v2Tag = Flac_File_ConstructorTests.getId3v2Tag(false);
+        const apeTag = Flac_File_ConstructorTests.getApeTag();
+        const id3v1Tag = Flac_File_ConstructorTests.getId3v1Tag();
+        const xiphTag = Flac_File_ConstructorTests.getXiphTag();
+        const picBlock = Flac_File_ConstructorTests.getPictureBlock();
         const extraBlocks = [
             picBlock,
             FlacBlock.fromData(FlacBlockType.Padding, ByteVector.fromSize(Flac_File_ConstructorTests.standardPadding)),
@@ -926,7 +929,7 @@ import {Picture} from "../../src";
         const endTagBytes = id3v1Tag.render();
         return ByteVector.concatenate(
             startTagBytes,
-            this.getBasicFile(extraBlocks),
+            Flac_File_ConstructorTests.getBasicFile(extraBlocks),
             endTagBytes
         );
     }

--- a/test-unit/flac/flacStreamHeaderTests.ts
+++ b/test-unit/flac/flacStreamHeaderTests.ts
@@ -30,11 +30,11 @@ import {Testers} from "../utilities/testers";
     public constructor_invalidSampleRate() {
         // Arrange
         const data = ByteVector.concatenate(
-            ByteVector.fromUInt(0x12345678),
-            ByteVector.fromUInt(0x23456789),
-            ByteVector.fromUInt(0x34560000),
-            ByteVector.fromUInt(0x05678901),
-            ByteVector.fromUInt(0x56789012)
+            ByteVector.fromUint(0x12345678),
+            ByteVector.fromUint(0x23456789),
+            ByteVector.fromUint(0x34560000),
+            ByteVector.fromUint(0x05678901),
+            ByteVector.fromUint(0x56789012)
         );
 
         // Act / Assert
@@ -45,11 +45,11 @@ import {Testers} from "../utilities/testers";
     public constructor_nonZeroSamples() {
         // Arrange
         const data = ByteVector.concatenate(
-            ByteVector.fromUInt(0x12345678),
-            ByteVector.fromUInt(0x23456789),
-            ByteVector.fromUInt(0x34567890),
-            ByteVector.fromUInt(0x45678901),
-            ByteVector.fromUInt(0x56789012)
+            ByteVector.fromUint(0x12345678),
+            ByteVector.fromUint(0x23456789),
+            ByteVector.fromUint(0x34567890),
+            ByteVector.fromUint(0x45678901),
+            ByteVector.fromUint(0x56789012)
         );
 
         // Act
@@ -69,11 +69,11 @@ import {Testers} from "../utilities/testers";
     public constructor_zeroSamples() {
         // Arrange
         const data = ByteVector.concatenate(
-            ByteVector.fromUInt(0x12345678),
-            ByteVector.fromUInt(0x23456789),
-            ByteVector.fromUInt(0x34567890),
-            ByteVector.fromUInt(0x45600000),
-            ByteVector.fromUInt(0x00009012)
+            ByteVector.fromUint(0x12345678),
+            ByteVector.fromUint(0x23456789),
+            ByteVector.fromUint(0x34567890),
+            ByteVector.fromUint(0x45600000),
+            ByteVector.fromUint(0x00009012)
         );
 
         // Act

--- a/test-unit/id3v2/frameTests.ts
+++ b/test-unit/id3v2/frameTests.ts
@@ -119,7 +119,7 @@ class TestFrame extends Frame {
         // Assert
         const expected = ByteVector.concatenate(
             header.render(4),
-            ByteVector.fromUInt(TestFrame.renderFieldData.length),
+            ByteVector.fromUint(TestFrame.renderFieldData.length),
             TestFrame.renderFieldData
         );
         Testers.bvEqual(output, expected);
@@ -152,7 +152,7 @@ class TestFrame extends Frame {
         const frame = new TestFrame(header);
         const data = ByteVector.concatenate(
             header.render(4),
-            ByteVector.fromUInt(TestFrame.renderFieldData.length),
+            ByteVector.fromUint(TestFrame.renderFieldData.length),
             TestFrame.renderFieldData
         );
 

--- a/test-unit/id3v2/playCountFrameTests.ts
+++ b/test-unit/id3v2/playCountFrameTests.ts
@@ -38,7 +38,7 @@ const assert = Chai.assert;
         header.frameSize = 4;
         const data = ByteVector.concatenate(
             header.render(4),
-            ByteVector.fromUInt(1234)
+            ByteVector.fromUint(1234)
         );
 
         // Act
@@ -55,7 +55,7 @@ const assert = Chai.assert;
         header.frameSize = 6;
         const data = ByteVector.concatenate(
             header.render(4),
-            0x00, 0x00, ByteVector.fromUInt(1234)
+            0x00, 0x00, ByteVector.fromUint(1234)
         );
 
         // Act
@@ -150,7 +150,7 @@ const assert = Chai.assert;
         header.frameSize = 4;
         const data = ByteVector.concatenate(
             header.render(4),
-            ByteVector.fromUInt(1234)
+            ByteVector.fromUint(1234)
         );
         const frame = PlayCountFrame.fromRawData(data, 4);
 

--- a/test-unit/id3v2/popularimeterFrameTests.ts
+++ b/test-unit/id3v2/popularimeterFrameTests.ts
@@ -106,7 +106,7 @@ const assert = Chai.assert;
             ByteVector.fromString("fux", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),
             0x05,
-            ByteVector.fromUInt(1234)
+            ByteVector.fromUint(1234)
         );
 
         // Act
@@ -316,7 +316,7 @@ const assert = Chai.assert;
             ByteVector.fromString("fux", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),
             0x05,
-            ByteVector.fromUInt(1234)
+            ByteVector.fromUint(1234)
         );
         const frame = PopularimeterFrame.fromRawData(data, 4);
 

--- a/test-unit/id3v2/synchronizedLyricsFrameTests.ts
+++ b/test-unit/id3v2/synchronizedLyricsFrameTests.ts
@@ -39,7 +39,7 @@ const assert = Chai.assert;
         const expected = ByteVector.concatenate(
             ByteVector.fromString(text.text, StringType.UTF16BE),
             ByteVector.getTextDelimiter(StringType.UTF16BE),
-            ByteVector.fromUInt(text.time),
+            ByteVector.fromUint(text.time),
         );
         Testers.bvEqual(output, expected);
     }

--- a/test-unit/mpeg/mpegAudioHeaderTests.ts
+++ b/test-unit/mpeg/mpegAudioHeaderTests.ts
@@ -157,7 +157,7 @@ const assert = Chai.assert;
     @test
     public fromData_noVbrHeaders() {
         // Arrange - MPEG2, Layer2, 64kbps, 22050kHz - padded
-        const data = ByteVector.fromUInt(0xFFF48200, true);
+        const data = ByteVector.fromUint(0xFFF48200, true);
         data.addByteVector(ByteVector.fromSize(100));
         const mockFile = TestFile.getFile(data);
 
@@ -189,7 +189,7 @@ const assert = Chai.assert;
     @test
     public fromData_hasXingHeader() {
         // Arrange - MPEG1, Layer1, 256kbps (via flags), 44100kHz, Stereo, not padded
-        const mpegFlags = ByteVector.fromUInt(0xFFFE8000, true);
+        const mpegFlags = ByteVector.fromUint(0xFFFE8000, true);
         const data = ByteVector.concatenate(
             ByteVector.fromSize(1),
             mpegFlags,
@@ -197,8 +197,8 @@ const assert = Chai.assert;
             ByteVector.concatenate(
                 XingHeader.fileIdentifier,
                 0x00, 0x00, 0x00, 0x03,
-                ByteVector.fromUInt(12),
-                ByteVector.fromUInt(23)
+                ByteVector.fromUint(12),
+                ByteVector.fromUint(23)
             ) // Calculates to 2kbps via Xing header
         );
         const mockFile = TestFile.getFile(data);
@@ -236,7 +236,7 @@ const assert = Chai.assert;
     @test
     public fromData_hasVbriHeader() {
         // Arrange - MPEG1, Layer1, 256kbps (via flags), 44100kHz, Stereo, not padded
-        const mpegFlags = ByteVector.fromUInt(0xFFFE8000, true);
+        const mpegFlags = ByteVector.fromUint(0xFFFE8000, true);
         const data = ByteVector.concatenate(
             ByteVector.fromSize(1),
             mpegFlags,
@@ -244,8 +244,8 @@ const assert = Chai.assert;
             ByteVector.concatenate(
                 VbriHeader.fileIdentifier,
                 ByteVector.fromSize(6),
-                ByteVector.fromUInt(234),
-                ByteVector.fromUInt(123),
+                ByteVector.fromUint(234),
+                ByteVector.fromUint(123),
                 ByteVector.fromSize(6)
             )
         );
@@ -592,7 +592,8 @@ const assert = Chai.assert;
     public streamLength_set_noVbr() {
         // Arrange - MPEG2, Layer2, 64kbps, 22050kHz - padded
         const header = MpegAudioHeader.fromInfo(0xFFF48200, 1234, XingHeader.unknown, VbriHeader.unknown);
-        const _ = header.durationMilliseconds; // Force calculation of durationMilliseconds
+        // noinspection JSUnusedLocalSymbols Force calculation of durationMilliseconds
+        const _ = header.durationMilliseconds;
 
         // Act
         header.streamLength = 2345;
@@ -706,7 +707,7 @@ const assert = Chai.assert;
         // Arrange
         const data = ByteVector.concatenate(
             ByteVector.fromSize(File.bufferSize * 2),
-            ByteVector.fromUInt(0xFFF48200, true),
+            ByteVector.fromUint(0xFFF48200, true),
             ByteVector.fromSize(100)
         );
         const mockFile = TestFile.getFile(data);
@@ -723,7 +724,7 @@ const assert = Chai.assert;
         // Arrange
         const data = ByteVector.concatenate(
             ByteVector.fromSize(File.bufferSize),
-            ByteVector.fromUInt(0xFFF48200, true),
+            ByteVector.fromUint(0xFFF48200, true),
             ByteVector.fromSize(100)
         );
         const mockFile = TestFile.getFile(data);

--- a/test-unit/mpeg/vbriHeaderTests.ts
+++ b/test-unit/mpeg/vbriHeaderTests.ts
@@ -50,8 +50,8 @@ const assert = Chai.assert;
         const data = ByteVector.concatenate(
             VbriHeader.fileIdentifier,
             ByteVector.fromSize(6),
-            ByteVector.fromUInt(123),
-            ByteVector.fromUInt(234)
+            ByteVector.fromUint(123),
+            ByteVector.fromUint(234)
         );
 
         // Act

--- a/test-unit/mpeg/xingHeaderTests.ts
+++ b/test-unit/mpeg/xingHeaderTests.ts
@@ -51,7 +51,7 @@ const assert = Chai.assert;
         const data = ByteVector.concatenate(
             XingHeader.fileIdentifier,
             0x00, 0x00, 0x00, 0x02,
-            ByteVector.fromUInt(123)
+            ByteVector.fromUint(123)
         );
 
         // Act
@@ -69,7 +69,7 @@ const assert = Chai.assert;
         const data = ByteVector.concatenate(
             XingHeader.fileIdentifier,
             0x00, 0x00, 0x00, 0x01,
-            ByteVector.fromUInt(123)
+            ByteVector.fromUint(123)
         );
 
         // Act
@@ -87,8 +87,8 @@ const assert = Chai.assert;
         const data = ByteVector.concatenate(
             XingHeader.fileIdentifier,
             0x00, 0x00, 0x00, 0x03,
-            ByteVector.fromUInt(123),
-            ByteVector.fromUInt(234)
+            ByteVector.fromUint(123),
+            ByteVector.fromUint(234)
         );
 
         // Act

--- a/test-unit/riff/aviHeaderTests.ts
+++ b/test-unit/riff/aviHeaderTests.ts
@@ -73,7 +73,7 @@ const assert = Chai.assert;
         list.setValues(AviHeader.headerChunkId, [Resources.getAviHeader()]);
 
         const header1Data = ByteVector.concatenate(
-            ByteVector.fromUInt(AviStreamType.MIDI_STREAM, false),
+            ByteVector.fromUint(AviStreamType.MIDI_STREAM, false),
             ByteVector.fromSize(52)
         );
         const streamList1 = RiffList.fromEmpty(AviStream.listType);
@@ -81,7 +81,7 @@ const assert = Chai.assert;
         streamList1.setValues(AviStream.formatChunkId, [ByteVector.empty()]);
 
         const header2Data = ByteVector.concatenate(
-            ByteVector.fromUInt(AviStreamType.TEXT_STREAM, false),
+            ByteVector.fromUint(AviStreamType.TEXT_STREAM, false),
             ByteVector.fromSize(52)
         );
         const streamList2 = RiffList.fromEmpty(AviStream.listType);
@@ -113,7 +113,7 @@ const assert = Chai.assert;
         list.setValues(AviHeader.headerChunkId, [Resources.getAviHeader()]);
 
         const header1Data = ByteVector.concatenate(
-            ByteVector.fromUInt(AviStreamType.AUDIO_STREAM, false),
+            ByteVector.fromUint(AviStreamType.AUDIO_STREAM, false),
             ByteVector.fromSize(52)
         );
         const streamList1 = RiffList.fromEmpty(AviStream.listType);

--- a/test-unit/riff/resources.ts
+++ b/test-unit/riff/resources.ts
@@ -10,8 +10,8 @@ export default {
         return ByteVector.concatenate(
             ByteVector.fromUShort(type, false), // Format tag
             ByteVector.fromUShort(3, false), // Number of channels
-            ByteVector.fromUInt(1234, false), // Samples per second
-            ByteVector.fromUInt(2345, false), // Average bytes per second
+            ByteVector.fromUint(1234, false), // Samples per second
+            ByteVector.fromUint(2345, false), // Average bytes per second
             ByteVector.fromUShort(88, false), // Block align
             ByteVector.fromUShort(16, false) // Bits per sample
         );
@@ -52,34 +52,34 @@ export default {
     },
     getAviHeader(): ByteVector {
         return ByteVector.concatenate(
-            ByteVector.fromUInt(1234, false), // Microseconds per frame
-            ByteVector.fromUInt(2345, false), // Max bytes per second
-            ByteVector.fromUInt(3456, false), // Padding granularity
-            ByteVector.fromUInt(4567, false), // Flags
-            ByteVector.fromUInt(5678, false), // Total frames
-            ByteVector.fromUInt(6789, false), // Initial frames
-            ByteVector.fromUInt(7890, false), // Streams
-            ByteVector.fromUInt(8901, false), // Suggested buffer size
-            ByteVector.fromUInt(9012, false), // Width
-            ByteVector.fromUInt(123, false), // Height
+            ByteVector.fromUint(1234, false), // Microseconds per frame
+            ByteVector.fromUint(2345, false), // Max bytes per second
+            ByteVector.fromUint(3456, false), // Padding granularity
+            ByteVector.fromUint(4567, false), // Flags
+            ByteVector.fromUint(5678, false), // Total frames
+            ByteVector.fromUint(6789, false), // Initial frames
+            ByteVector.fromUint(7890, false), // Streams
+            ByteVector.fromUint(8901, false), // Suggested buffer size
+            ByteVector.fromUint(9012, false), // Width
+            ByteVector.fromUint(123, false), // Height
             ByteVector.fromSize(16), // Reserved
         );
     },
     getAviStreamHeaderData(type: AviStreamType) {
         return ByteVector.concatenate(
-            ByteVector.fromUInt(type, false), // type
-            ByteVector.fromUInt(0x23456789, false), // handler
-            ByteVector.fromUInt(0x34567890, false), // Flags
+            ByteVector.fromUint(type, false), // type
+            ByteVector.fromUint(0x23456789, false), // handler
+            ByteVector.fromUint(0x34567890, false), // Flags
             ByteVector.fromUShort(0x1234, false),   // Priority
             ByteVector.fromUShort(0x2345, false),   // Language
-            ByteVector.fromUInt(0x45678901, false), // Initial Frames
-            ByteVector.fromUInt(0x56789012, false), // Scale
-            ByteVector.fromUInt(0x67890123, false), // Rate
-            ByteVector.fromUInt(0x78901234, false), // Start
-            ByteVector.fromUInt(0x89012345, false), // Length
-            ByteVector.fromUInt(0x90123456, false), // Suggested Buffer Size
-            ByteVector.fromUInt(0x01234567, false), // Quality
-            ByteVector.fromUInt(0x11234567, false), // Sample size
+            ByteVector.fromUint(0x45678901, false), // Initial Frames
+            ByteVector.fromUint(0x56789012, false), // Scale
+            ByteVector.fromUint(0x67890123, false), // Rate
+            ByteVector.fromUint(0x78901234, false), // Start
+            ByteVector.fromUint(0x89012345, false), // Length
+            ByteVector.fromUint(0x90123456, false), // Suggested Buffer Size
+            ByteVector.fromUint(0x01234567, false), // Quality
+            ByteVector.fromUint(0x11234567, false), // Sample size
             ByteVector.fromUShort(0x3456, false),   // left
             ByteVector.fromUShort(0x4567, false),   // top
             ByteVector.fromUShort(0x5678, false),   // right
@@ -112,17 +112,17 @@ export default {
     getVideoFormatBlock(fourcc: number): ByteVector {
         return ByteVector.concatenate(
             ByteVector.fromSize(10), // Offset
-            ByteVector.fromUInt(40, false), // Size of the struct
-            ByteVector.fromUInt(123, false), // Width of image
-            ByteVector.fromUInt(234, false), // Height of image
+            ByteVector.fromUint(40, false), // Size of the struct
+            ByteVector.fromUint(123, false), // Width of image
+            ByteVector.fromUint(234, false), // Height of image
             ByteVector.fromUShort(345, false), // Number of planes
             ByteVector.fromUShort(456, false), // Average bits per pixel
-            ByteVector.fromUInt(fourcc, false), // FOURCC
-            ByteVector.fromUInt(567, false), // Size of the image
-            ByteVector.fromUInt(678, false), // Pixels per meter X
-            ByteVector.fromUInt(789, false), // Pixels per meter Y
-            ByteVector.fromUInt(890, false), // Colors used
-            ByteVector.fromUInt(1234, false), // Important colors
+            ByteVector.fromUint(fourcc, false), // FOURCC
+            ByteVector.fromUint(567, false), // Size of the image
+            ByteVector.fromUint(678, false), // Pixels per meter X
+            ByteVector.fromUint(789, false), // Pixels per meter Y
+            ByteVector.fromUint(890, false), // Colors used
+            ByteVector.fromUint(1234, false), // Important colors
         );
     },
     getWaveFormatBlock(): ByteVector {

--- a/test-unit/riff/riffFileTests.ts
+++ b/test-unit/riff/riffFileTests.ts
@@ -33,7 +33,7 @@ import {Testers} from "../utilities/testers";
         // Arrange
         const fileBytes = ByteVector.concatenate(
             ByteVector.fromString("FOOO"),
-            ByteVector.fromUInt(100, false),
+            ByteVector.fromUint(100, false),
             Resources.getDataChunk()
         );
         const testAbstraction = TestFile.getFileAbstraction(fileBytes);
@@ -1307,7 +1307,7 @@ import {Testers} from "../utilities/testers";
     private static getFileBytes(dataBytes: ByteVector): ByteVector {
         return ByteVector.concatenate(
             RiffFile.fileIdentifier,
-            ByteVector.fromUInt(dataBytes.length, false),
+            ByteVector.fromUint(dataBytes.length, false),
             dataBytes
         );
     }

--- a/test-unit/riff/riffListTests.ts
+++ b/test-unit/riff/riffListTests.ts
@@ -18,32 +18,32 @@ const data4 = ByteVector.fromString("nan", undefined, undefined, false);
 const data5 = ByteVector.fromString("234", undefined, undefined, false);
 const sampleData = ByteVector.concatenate(
     ByteVector.fromString("TXT1"),
-    ByteVector.fromUInt(data1.length, false),
+    ByteVector.fromUint(data1.length, false),
     data1, 0x00,
     ByteVector.fromString("TXT1"),
-    ByteVector.fromUInt(data2.length, false),
+    ByteVector.fromUint(data2.length, false),
     data2,
     ByteVector.fromString("TXT2"),
-    ByteVector.fromUInt(data3.length, false),
+    ByteVector.fromUint(data3.length, false),
     data3,
     ByteVector.fromString("TXT3"),
-    ByteVector.fromUInt(data4.length, false),
+    ByteVector.fromUint(data4.length, false),
     data4, 0x00,
     ByteVector.fromString("TXT3"),
-    ByteVector.fromUInt(data5.length, false),
+    ByteVector.fromUint(data5.length, false),
     data5, 0x00
 );
 
 const sampleList = ByteVector.concatenate(
     ByteVector.fromString(RiffList.identifierFourcc),
-    ByteVector.fromUInt(sampleData.length + 4, false),
+    ByteVector.fromUint(sampleData.length + 4, false),
     ByteVector.fromString("fooo"),
     sampleData
 );
 
 const sampleNestedList = ByteVector.concatenate(
     ByteVector.fromString(RiffList.identifierFourcc),
-    ByteVector.fromUInt(sampleList.length + 4, false),
+    ByteVector.fromUint(sampleList.length + 4, false),
     ByteVector.fromString("baar"),
     sampleList
 );
@@ -65,7 +65,7 @@ const sampleNestedList = ByteVector.concatenate(
         // Arrange
         const data = ByteVector.concatenate(
             ByteVector.fromString(RiffList.identifierFourcc),
-            ByteVector.fromUInt(0, false)
+            ByteVector.fromUint(0, false)
         );
         const mockFile = TestFile.getFile(data);
 
@@ -252,7 +252,7 @@ const sampleNestedList = ByteVector.concatenate(
         // Assert
         const expected = ByteVector.concatenate(
             ByteVector.fromString(RiffList.identifierFourcc),
-            ByteVector.fromUInt(4, false),
+            ByteVector.fromUint(4, false),
             ByteVector.fromString("fooo")
         );
         assert.isOk(result);

--- a/test-unit/xiph/resources.ts
+++ b/test-unit/xiph/resources.ts
@@ -10,16 +10,16 @@ export default class XiphTestResources {
     public static readonly pictureIndexedColors = 234;
     public static readonly pictureType = PictureType.ColoredFish;
     public static readonly pictureBytes = ByteVector.concatenate(
-        ByteVector.fromUInt(XiphTestResources.pictureType),
-        ByteVector.fromUInt(XiphTestResources.pictureMimeType.length),
+        ByteVector.fromUint(XiphTestResources.pictureType),
+        ByteVector.fromUint(XiphTestResources.pictureMimeType.length),
         ByteVector.fromString(XiphTestResources.pictureMimeType),
-        ByteVector.fromUInt(XiphTestResources.pictureDescription.length),
+        ByteVector.fromUint(XiphTestResources.pictureDescription.length),
         ByteVector.fromString(XiphTestResources.pictureDescription),
-        ByteVector.fromUInt(XiphTestResources.pictureWidth),
-        ByteVector.fromUInt(XiphTestResources.pictureHeight),
-        ByteVector.fromUInt(XiphTestResources.pictureColorDepth),
-        ByteVector.fromUInt(XiphTestResources.pictureIndexedColors),
-        ByteVector.fromUInt(XiphTestResources.pictureData.length),
+        ByteVector.fromUint(XiphTestResources.pictureWidth),
+        ByteVector.fromUint(XiphTestResources.pictureHeight),
+        ByteVector.fromUint(XiphTestResources.pictureColorDepth),
+        ByteVector.fromUint(XiphTestResources.pictureIndexedColors),
+        ByteVector.fromUint(XiphTestResources.pictureData.length),
         XiphTestResources.pictureData
     );
     public static readonly pictureEncodedBytes = Buffer.from(XiphTestResources.pictureBytes.data)

--- a/test-unit/xiph/xiphCommentTests.ts
+++ b/test-unit/xiph/xiphCommentTests.ts
@@ -24,9 +24,9 @@ import {TagTesters, Testers} from "../utilities/testers";
     public fromData_noData() {
         // Arrange
         const data = ByteVector.concatenate(
-            ByteVector.fromUInt(9, false),
+            ByteVector.fromUint(9, false),
             ByteVector.fromString("foobarbaz"),
-            ByteVector.fromUInt(0, false)
+            ByteVector.fromUint(0, false)
         );
 
         // Act
@@ -46,16 +46,16 @@ import {TagTesters, Testers} from "../utilities/testers";
     public fromData_hasValues() {
         // Arrange
         const data = ByteVector.concatenate(
-            ByteVector.fromUInt(3, false),
+            ByteVector.fromUint(3, false),
             ByteVector.fromString("foo"),
-            ByteVector.fromUInt(4, false),
-            ByteVector.fromUInt(9, false),
+            ByteVector.fromUint(4, false),
+            ByteVector.fromUint(9, false),
             ByteVector.fromString("TITLE=bar"),
-            ByteVector.fromUInt(7, false),
+            ByteVector.fromUint(7, false),
             ByteVector.fromString("FUX=bux"),
-            ByteVector.fromUInt(7, false),
+            ByteVector.fromUint(7, false),
             ByteVector.fromString("FUX=qux"),
-            ByteVector.fromUInt(15, false),
+            ByteVector.fromUint(15, false),
             ByteVector.fromString("Malformed_field")
         );
 
@@ -81,14 +81,14 @@ import {TagTesters, Testers} from "../utilities/testers";
         const oldPictureItem = `COVERART=${Buffer.from(oldPictureData.data).toString("base64")}`;
         const newPictureItem = `METADATA_BLOCK_PICTURE=${XiphTestResources.pictureEncodedBytes}`;
         const data = ByteVector.concatenate(
-            ByteVector.fromUInt(3, false),
+            ByteVector.fromUint(3, false),
             ByteVector.fromString("foo"),
-            ByteVector.fromUInt(3, false),
-            ByteVector.fromUInt(9, false),
+            ByteVector.fromUint(3, false),
+            ByteVector.fromUint(9, false),
             ByteVector.fromString("TITLE=bar"),
-            ByteVector.fromUInt(oldPictureItem.length, false),
+            ByteVector.fromUint(oldPictureItem.length, false),
             ByteVector.fromString(oldPictureItem),
-            ByteVector.fromUInt(newPictureItem.length, false),
+            ByteVector.fromUint(newPictureItem.length, false),
             ByteVector.fromString(newPictureItem)
         );
 
@@ -848,22 +848,22 @@ import {TagTesters, Testers} from "../utilities/testers";
     private static readonly title1 = "bar";
     private static readonly title2 = "baz";
     private static readonly encodedOldPictureData = Buffer.from(ByteVector.fromString("fuxbuxqux").data).toString("base64");
-    private getTestComment() {
+    private static getTestComment() {
         const oldPictureItem = `COVERART=${Xiph_Comment_MethodTests.encodedOldPictureData}`;
         const newPictureItem = `METADATA_BLOCK_PICTURE=${XiphTestResources.pictureEncodedBytes}`;
         const titleItem1 = `TITLE=${Xiph_Comment_MethodTests.title1}`;
         const titleItem2 = `TITLE=${Xiph_Comment_MethodTests.title2}`;
         const data = ByteVector.concatenate(
-            ByteVector.fromUInt(Xiph_Comment_MethodTests.vendorId.length, false),
+            ByteVector.fromUint(Xiph_Comment_MethodTests.vendorId.length, false),
             ByteVector.fromString(Xiph_Comment_MethodTests.vendorId),
-            ByteVector.fromUInt(4, false),
-            ByteVector.fromUInt(titleItem1.length, false),
+            ByteVector.fromUint(4, false),
+            ByteVector.fromUint(titleItem1.length, false),
             ByteVector.fromString(titleItem1),
-            ByteVector.fromUInt(titleItem2.length, false),
+            ByteVector.fromUint(titleItem2.length, false),
             ByteVector.fromString(titleItem2),
-            ByteVector.fromUInt(oldPictureItem.length, false),
+            ByteVector.fromUint(oldPictureItem.length, false),
             ByteVector.fromString(oldPictureItem),
-            ByteVector.fromUInt(newPictureItem.length, false),
+            ByteVector.fromUint(newPictureItem.length, false),
             ByteVector.fromString(newPictureItem)
         );
         return XiphComment.fromData(data);
@@ -872,7 +872,7 @@ import {TagTesters, Testers} from "../utilities/testers";
     @test
     public clear() {
         // Arrange
-        const comment = this.getTestComment();
+        const comment = Xiph_Comment_MethodTests.getTestComment();
 
         // Act
         comment.clear();
@@ -890,7 +890,7 @@ import {TagTesters, Testers} from "../utilities/testers";
     @test
     public getField_invalidParameters() {
         // Arrange
-        const comment = this.getTestComment();
+        const comment = Xiph_Comment_MethodTests.getTestComment();
 
         // Act / Assert
         Testers.testString(comment.getField);
@@ -901,7 +901,7 @@ import {TagTesters, Testers} from "../utilities/testers";
     @test
     public getField_fieldExists() {
         // Arrange
-        const comment = this.getTestComment();
+        const comment = Xiph_Comment_MethodTests.getTestComment();
 
         // Act
         const output = comment.getField("TitlE");
@@ -941,7 +941,7 @@ import {TagTesters, Testers} from "../utilities/testers";
     @test
     public getFieldFirstValue_invalidValues() {
         // Arrange
-        const comment = this.getTestComment();
+        const comment = Xiph_Comment_MethodTests.getTestComment();
 
         // Act / Assert
         Testers.testString(comment.getFieldFirstValue);
@@ -952,7 +952,7 @@ import {TagTesters, Testers} from "../utilities/testers";
     @test
     public getFieldFirstValue_fieldExists() {
         // Arrange
-        const comment = this.getTestComment();
+        const comment = Xiph_Comment_MethodTests.getTestComment();
 
         // Act
         const output = comment.getFieldFirstValue("TitlE");
@@ -964,7 +964,7 @@ import {TagTesters, Testers} from "../utilities/testers";
     @test
     public getFieldFirstValue_fieldDoesNotExist() {
         // Arrange
-        const comment = this.getTestComment();
+        const comment = Xiph_Comment_MethodTests.getTestComment();
 
         // Act
         const output = comment.getFieldFirstValue("foobar");
@@ -976,7 +976,7 @@ import {TagTesters, Testers} from "../utilities/testers";
     @test
     public removeField_invalidValues() {
         // Arrange
-        const comment = this.getTestComment();
+        const comment = Xiph_Comment_MethodTests.getTestComment();
 
         // Act / Assert
         Testers.testString(comment.removeField);
@@ -987,7 +987,7 @@ import {TagTesters, Testers} from "../utilities/testers";
     @test
     public removeValue_fieldExists() {
         // Arrange
-        const comment = this.getTestComment();
+        const comment = Xiph_Comment_MethodTests.getTestComment();
 
         // Act
         comment.removeField("TitlE");
@@ -1000,7 +1000,7 @@ import {TagTesters, Testers} from "../utilities/testers";
     @test
     public removeValue_fieldDoesNotExist() {
         // Arrange
-        const comment = this.getTestComment();
+        const comment = Xiph_Comment_MethodTests.getTestComment();
 
         // Act
         comment.removeField("foobar");
@@ -1019,8 +1019,8 @@ import {TagTesters, Testers} from "../utilities/testers";
 
         // Assert
         const expectedOutput = ByteVector.concatenate(
-            ByteVector.fromUInt(0, false),
-            ByteVector.fromUInt(0, false),
+            ByteVector.fromUint(0, false),
+            ByteVector.fromUint(0, false),
         );
         assert.isTrue(ByteVector.equal(output, expectedOutput));
     }
@@ -1035,8 +1035,8 @@ import {TagTesters, Testers} from "../utilities/testers";
 
         // Assert
         const expectedOutput = ByteVector.concatenate(
-            ByteVector.fromUInt(0, false),
-            ByteVector.fromUInt(0, false),
+            ByteVector.fromUint(0, false),
+            ByteVector.fromUint(0, false),
             0x01
         );
         Testers.bvEqual(output, expectedOutput);
@@ -1045,7 +1045,7 @@ import {TagTesters, Testers} from "../utilities/testers";
     @test
     public render_hasContents() {
         // Arrange
-        const comment = this.getTestComment();
+        const comment = Xiph_Comment_MethodTests.getTestComment();
 
         // Act
         const output = comment.render(false);
@@ -1057,16 +1057,16 @@ import {TagTesters, Testers} from "../utilities/testers";
         const pictureItem1 = `METADATA_BLOCK_PICTURE=${picture1EncodedBytes}`;
         const pictureItem2 = `METADATA_BLOCK_PICTURE=${XiphTestResources.pictureEncodedBytes}`;
         const expected = ByteVector.concatenate(
-            ByteVector.fromUInt(Xiph_Comment_MethodTests.vendorId.length, false),
+            ByteVector.fromUint(Xiph_Comment_MethodTests.vendorId.length, false),
             ByteVector.fromString(Xiph_Comment_MethodTests.vendorId),
-            ByteVector.fromUInt(4, false),
-            ByteVector.fromUInt(titleItem1.length, false),
+            ByteVector.fromUint(4, false),
+            ByteVector.fromUint(titleItem1.length, false),
             ByteVector.fromString(titleItem1),
-            ByteVector.fromUInt(titleItem2.length, false),
+            ByteVector.fromUint(titleItem2.length, false),
             ByteVector.fromString(titleItem2),
-            ByteVector.fromUInt(pictureItem1.length, false),
+            ByteVector.fromUint(pictureItem1.length, false),
             ByteVector.fromString(pictureItem1),
-            ByteVector.fromUInt(pictureItem2.length, false),
+            ByteVector.fromUint(pictureItem2.length, false),
             ByteVector.fromString(pictureItem2)
         );
         Testers.bvEqual(output, expected);
@@ -1075,7 +1075,7 @@ import {TagTesters, Testers} from "../utilities/testers";
     @test
     public setFieldAsString_invalidValues() {
         // Arrange
-        const comment = this.getTestComment();
+        const comment = Xiph_Comment_MethodTests.getTestComment();
 
         // Act / Assert
         Testers.testString((v: string) => comment.setFieldAsStrings(v));
@@ -1086,7 +1086,7 @@ import {TagTesters, Testers} from "../utilities/testers";
     @test
     public setFieldAsString_removesField() {
         // Arrange
-        const comment = this.getTestComment();
+        const comment = Xiph_Comment_MethodTests.getTestComment();
 
         // Act
         comment.setFieldAsStrings("TitlE");
@@ -1099,7 +1099,7 @@ import {TagTesters, Testers} from "../utilities/testers";
     @test
     public setFieldAsString_allValuesFilteredOutRemovesField() {
         // Arrange
-        const comment = this.getTestComment();
+        const comment = Xiph_Comment_MethodTests.getTestComment();
 
         // Act
         comment.setFieldAsStrings("TitlE", "", undefined, null, "   ");
@@ -1112,7 +1112,7 @@ import {TagTesters, Testers} from "../utilities/testers";
     @test
     public setFieldAsString_fieldExists() {
         // Arrange
-        const comment = this.getTestComment();
+        const comment = Xiph_Comment_MethodTests.getTestComment();
 
         // Act
         comment.setFieldAsStrings("TitlE", "nobody's", "accusing", "you");
@@ -1138,7 +1138,7 @@ import {TagTesters, Testers} from "../utilities/testers";
     @test
     public setFieldAsUint_invalidValues() {
         // Arrange
-        const comment = this.getTestComment();
+        const comment = Xiph_Comment_MethodTests.getTestComment();
 
         // Act / Assert
         Testers.testString((v: string) => comment.setFieldAsUint(v, 0, 0));
@@ -1151,7 +1151,7 @@ import {TagTesters, Testers} from "../utilities/testers";
     @test
     public setFieldAsUint_removesField() {
         // Arrange
-        const comment = this.getTestComment();
+        const comment = Xiph_Comment_MethodTests.getTestComment();
 
         // Act
         comment.setFieldAsUint("TitlE", 0);
@@ -1164,7 +1164,7 @@ import {TagTesters, Testers} from "../utilities/testers";
     @test
     public setFieldAsUint_fieldExists() {
         // Arrange
-        const comment = this.getTestComment();
+        const comment = Xiph_Comment_MethodTests.getTestComment();
 
         // Act
         comment.setFieldAsUint("TitlE", 3, 3);


### PR DESCRIPTION
Calling it `UInt` isn't standard for javascript. Call it `Uint`

**Breaking Changes**:
* `ByteVector.fromUInt` renamed to `ByteVector.fromUint`
* `ByteVector.toUInt` renamed to `ByteVector.toUint`
* `ApeTag.getUInt32Value` renamed to `ApeTag.getUint32Value`

Resolves #1