### PR TITLE
NumberUtils.hasFlag

### DIFF
--- a/src/aac/aacFile.ts
+++ b/src/aac/aacFile.ts
@@ -6,6 +6,7 @@ import {CorruptFileError} from "../errors";
 import {File, ReadStyle} from "../file";
 import {IFileAbstraction} from "../fileAbstraction";
 import {TagTypes} from "../tag";
+import {NumberUtils} from "../utils";
 
 /**
  * This class extends {@link File} to provide tagging and properties for ADTS AAC audio files.
@@ -28,7 +29,7 @@ export default class AacFile extends SandwichFile {
 
     protected readProperties(readStyle: ReadStyle): Properties {
         // Skip if we're not reading the properties
-        if ((readStyle & ReadStyle.Average) === 0) {
+        if (!NumberUtils.hasFlag(readStyle, ReadStyle.Average)) {
             return undefined;
         }
 

--- a/src/aiff/aiffFile.ts
+++ b/src/aiff/aiffFile.ts
@@ -1,12 +1,13 @@
+import AiffStreamHeader from "./aiffStreamHeader";
 import Id3v2Tag from "../id3v2/id3v2Tag";
 import Properties from "../properties";
 import {ByteVector} from "../byteVector";
+import {CorruptFileError} from "../errors";
 import {File, FileAccessMode, ReadStyle} from "../file";
 import {IFileAbstraction} from "../fileAbstraction";
 import {Tag, TagTypes} from "../tag";
 import {SeekOrigin} from "../stream";
-import {CorruptFileError} from "../errors";
-import AiffStreamHeader from "./aiffStreamHeader";
+import {NumberUtils} from "../utils";
 
 export default class AiffFile extends File {
 
@@ -99,7 +100,7 @@ export default class AiffFile extends File {
 
     /** @inheritDoc */
     public removeTags(types: TagTypes): void {
-        if ((types & TagTypes.Id3v2) > 0) {
+        if (NumberUtils.hasFlag(types, TagTypes.Id3v2)) {
             this._tag = undefined;
         }
     }

--- a/src/ape/apeFile.ts
+++ b/src/ape/apeFile.ts
@@ -5,6 +5,7 @@ import {ApeStreamHeader} from "./apeStreamHeader";
 import {File, ReadStyle} from "../file";
 import {IFileAbstraction} from "../fileAbstraction";
 import {TagTypes} from "../tag";
+import {NumberUtils} from "../utils";
 
 /**
  * Provides tagging and properties support for Monkey's Audio APE files.
@@ -32,7 +33,7 @@ export default class ApeFile extends SandwichFile {
     /** @inheritDoc */
     protected readProperties(readStyle: ReadStyle): Properties {
         // Skip if we're not reading the properties
-        if ((readStyle & ReadStyle.Average) === 0) {
+        if (!NumberUtils.hasFlag(readStyle, ReadStyle.Average)) {
             return undefined;
         }
 

--- a/src/ape/apeTag.ts
+++ b/src/ape/apeTag.ts
@@ -8,7 +8,7 @@ import {CorruptFileError} from "../errors";
 import {File, FileAccessMode} from "../file";
 import {IPicture, PictureType} from "../iPicture";
 import {Tag, TagTypes} from "../tag";
-import {Guards, StringComparison} from "../utils";
+import {Guards, NumberUtils, StringComparison} from "../utils";
 
 /**
  * Provides a representation of an APEv2 tag which can be read from and written to disk.
@@ -70,7 +70,7 @@ export default class ApeTag extends Tag {
         tag._footer = ApeTagFooter.fromData(data.mid(data.length - ApeTagFooter.size));
 
         // If we've read a header at the end of the block, the block is invalid
-        if ((tag._footer.flags & ApeTagFooterFlags.IsHeader) !== 0) {
+        if (NumberUtils.hasFlag(tag._footer.flags, ApeTagFooterFlags.IsHeader)) {
             throw new CorruptFileError("Footer was actually a header");
         }
         if ((data.length < tag._footer.requiredDataSize)) {
@@ -117,7 +117,7 @@ export default class ApeTag extends Tag {
 
         // If we've read a header, we don't have to seek to read the content. If we've read a
         // footer, we need to move back to the start of the tag.
-        if ((tag._footer.flags & ApeTagFooterFlags.IsHeader) === 0) {
+        if (!NumberUtils.hasFlag(tag._footer.flags, ApeTagFooterFlags.IsHeader)) {
             file.seek(position - tag._footer.itemSize);
         }
         tag.parse(file.readBlock(tag._footer.requiredDataSize - ApeTagFooter.size));
@@ -133,7 +133,7 @@ export default class ApeTag extends Tag {
      * Gets whether or not the current instance has a header when rendered.
      */
     public get isHeaderPresent(): boolean {
-        return !!this._footer && (this._footer.flags & ApeTagFooterFlags.HeaderPresent) !== 0;
+        return !!this._footer && NumberUtils.hasFlag(this._footer.flags, ApeTagFooterFlags.HeaderPresent);
     }
     /**
      * Sets whether or not the current instance has a header when rendered.

--- a/src/ape/apeTagFooter.ts
+++ b/src/ape/apeTagFooter.ts
@@ -1,6 +1,6 @@
 import {ByteVector, StringType} from "../byteVector";
 import {CorruptFileError} from "../errors";
-import {Guards} from "../utils";
+import {Guards, NumberUtils} from "../utils";
 
 /**
  * Indicates the flags applied to a {@link ApeTagFooter} object.
@@ -137,7 +137,7 @@ export class ApeTagFooter {
     public get tagSize(): number {
         // @TODO: Shouldn't this take into consideration footer missing flags?
         return this._itemSize + ApeTagFooter.size +
-            ((this._flags & ApeTagFooterFlags.HeaderPresent) !== 0 ? ApeTagFooter.size : 0);
+            (NumberUtils.hasFlag(this._flags, ApeTagFooterFlags.HeaderPresent) ? ApeTagFooter.size : 0);
     }
 
     /**
@@ -154,7 +154,7 @@ export class ApeTagFooter {
     }
 
     public renderHeader(): ByteVector {
-        return (this.flags & ApeTagFooterFlags.HeaderPresent) !== 0
+        return NumberUtils.hasFlag(this.flags, ApeTagFooterFlags.HeaderPresent)
             ? this.render(true)
             : ByteVector.empty();
     }
@@ -177,15 +177,15 @@ export class ApeTagFooter {
 
         // Render and add the flags
         let flags = 0;
-        if ((this.flags & ApeTagFooterFlags.HeaderPresent) !== 0) {
-            flags = (flags | ApeTagFooterFlags.HeaderPresent) >>> 0; // @TODO: Replace all bitwise logic with >>> 0
+        if (NumberUtils.hasFlag(this.flags, ApeTagFooterFlags.HeaderPresent)) {
+            flags = NumberUtils.uintOr(flags, ApeTagFooterFlags.HeaderPresent);
         }
 
         // Footer is always present
         if (isHeader) {
-            flags = (flags | ApeTagFooterFlags.IsHeader) >>> 0;
+            flags = NumberUtils.uintOr(flags, ApeTagFooterFlags.IsHeader);
         } else {
-            flags = (flags & ~ApeTagFooterFlags.IsHeader) >>> 0;
+            flags = NumberUtils.uintAnd(flags, ~ApeTagFooterFlags.IsHeader);
         }
         v.addByteVector(ByteVector.fromUint(flags, false));
 

--- a/src/ape/apeTagItem.ts
+++ b/src/ape/apeTagItem.ts
@@ -1,6 +1,6 @@
 import {ByteVector, StringType} from "../byteVector";
 import {CorruptFileError} from "../errors";
-import {Guards} from "../utils";
+import {Guards, NumberUtils} from "../utils";
 
 /**
  * Indicates the type of data stored in a {@link ApeTagItem} object.
@@ -73,8 +73,8 @@ export class ApeTagItem {
         const flags = data.mid(offset + 4, 4).toUint(false);
 
         // Read flag data
-        item._isReadonly = (flags & 1) > 0;
-        item._type = <ApeTagItemType> ((flags >> 1) & 3);
+        item._isReadonly = NumberUtils.hasFlag(flags, 1);
+        item._type = <ApeTagItemType> NumberUtils.uintAnd(NumberUtils.uintRShift(flags, 1), 3);
 
         // Read key
         const keyEndIndex = data.find(ByteVector.getTextDelimiter(StringType.UTF8), offset + 8);

--- a/src/asf/asfFile.ts
+++ b/src/asf/asfFile.ts
@@ -4,6 +4,7 @@ import Properties from "../properties";
 import {File, FileAccessMode, ReadStyle} from "../file";
 import {IFileAbstraction} from "../fileAbstraction";
 import {Tag, TagTypes} from "../tag";
+import {NumberUtils} from "../utils";
 
 /**
  * This class provides tagging and properties support for Microsoft's ASF files.
@@ -24,7 +25,7 @@ export default class AsfFile extends File {
 
             this._asfTag = AsfTag.fromHeader(header);
 
-            if ((propertiesStyle & ReadStyle.Average) !== 0) {
+            if (NumberUtils.hasFlag(propertiesStyle, ReadStyle.Average)) {
                 this._properties = header.properties;
             }
         } finally {
@@ -49,7 +50,7 @@ export default class AsfFile extends File {
 
     /** @inheritDoc */
     public removeTags(types: TagTypes): void {
-        if ((types & TagTypes.Asf) === TagTypes.Asf) {
+        if (NumberUtils.hasFlag(types, TagTypes.Asf)) {
             this._asfTag.clear();
         }
     }

--- a/src/byteVector.ts
+++ b/src/byteVector.ts
@@ -2,7 +2,7 @@ import * as IConv from "iconv-lite";
 import * as fs from "fs";
 import {IFileAbstraction} from "./fileAbstraction";
 import {IStream} from "./stream";
-import {Guards} from "./utils";
+import {Guards, NumberUtils} from "./utils";
 
 class IConvEncoding {
     public readonly encoding: string;
@@ -562,7 +562,8 @@ export class ByteVector {
     public get checksum(): number {
         let sum = 0;
         for (const b of this._data) {
-            sum = (sum << 8) ^ ByteVector._crcTable[((sum >> 24) & 0xFF) ^ b];
+            const index = NumberUtils.uintXor(NumberUtils.uintAnd(NumberUtils.uintRShift(sum, 24), 0xFF), b);
+            sum = NumberUtils.uintXor(NumberUtils.uintLShift(sum, 8), ByteVector._crcTable[index]);
         }
         return sum;
     }

--- a/src/combinedTag.ts
+++ b/src/combinedTag.ts
@@ -1,7 +1,7 @@
 import {IPicture} from "./iPicture";
-import {Tag, TagTypes} from "./tag";
-import {Guards} from "./utils";
 import {NotSupportedError} from "./errors";
+import {Tag, TagTypes} from "./tag";
+import {Guards, NumberUtils} from "./utils";
 
 /**
  * This class provides a unified way of accessing tag data from multiple tag types.
@@ -641,7 +641,7 @@ export default abstract class CombinedTag extends Tag {
      */
     public getTag<TTag extends Tag>(tagType: TagTypes): TTag {
         // Make sure the tag type can possibly be stored here
-        if ((tagType & this._supportedTagTypes) === 0) {
+        if (!NumberUtils.hasFlag(this._supportedTagTypes, tagType)) {
             return undefined;
         }
 
@@ -669,8 +669,7 @@ export default abstract class CombinedTag extends Tag {
         for (let i = this._tags.length - 1; i >= 0; i--) {
             const tag = this._tags[i];
 
-            const isMatch = (tag.tagTypes & tagTypes) !== 0;
-            if (isMatch) {
+            if (NumberUtils.hasFlag(tag.tagTypes, tagTypes)) {
                 if (tag instanceof CombinedTag) {
                     tag.removeTags(tagTypes);
                 } else {
@@ -695,10 +694,10 @@ export default abstract class CombinedTag extends Tag {
      * @param tagType Tag type that the caller wants to create
      */
     protected validateTagCreation(tagType: TagTypes): void {
-        if ((this._supportedTagTypes & tagType) === 0) {
+        if (!NumberUtils.hasFlag(this._supportedTagTypes, tagType)) {
             throw new NotSupportedError(`Tag of type ${tagType} is not supported on this CombinedTag`);
         }
-        if ((this.tagTypes & tagType) !== 0) {
+        if (NumberUtils.hasFlag(this.tagTypes, tagType)) {
             throw new Error(`Cannot create tag of type ${tagType} because one already exists`);
         }
     }

--- a/src/flac/flacFile.ts
+++ b/src/flac/flacFile.ts
@@ -14,6 +14,7 @@ import {IFileAbstraction} from "../fileAbstraction";
 import {FlacBlock, FlacBlockType} from "./flacBlock";
 import {ISandwichFile} from "../sandwich/sandwichFile";
 import {Tag, TagTypes} from "../tag";
+import {NumberUtils} from "../utils";
 
 /**
  * This class extends {@link File} to provide tagging and properties for FLAC audio files.
@@ -67,7 +68,9 @@ export default class FlacFile extends File implements ISandwichFile {
         //    complete tag information.
         const allTagTypes = [TagTypes.Xiph, TagTypes.Id3v2, TagTypes.Ape, TagTypes.Id3v1];
         for (const tagType of allTagTypes) {
-            if ((FlacFileSettings.defaultTagTypes & tagType) === 0 || (this._tag.tagTypes & tagType) !== 0) {
+            const isDefaultTag = NumberUtils.hasFlag(FlacFileSettings.defaultTagTypes, tagType);
+            const existsAlready = NumberUtils.hasFlag(this._tag.tagTypes, tagType);
+            if (!isDefaultTag || existsAlready) {
                 continue;
             }
 
@@ -211,11 +214,11 @@ export default class FlacFile extends File implements ISandwichFile {
 
     private readPictures(readStyle: ReadStyle): XiphPicture[] {
         return this._metadataBlocks.filter((b) => b.type === FlacBlockType.Picture)
-            .map((b) => XiphPicture.fromFlacBlock(b, (readStyle & ReadStyle.PictureLazy) !== 0));
+            .map((b) => XiphPicture.fromFlacBlock(b, NumberUtils.hasFlag(readStyle, ReadStyle.PictureLazy)));
     }
 
     private readProperties(readStyle: ReadStyle): Properties {
-        if ((readStyle & ReadStyle.Average) === 0) {
+        if (!NumberUtils.hasFlag(readStyle, ReadStyle.Average)) {
             return undefined;
         }
 

--- a/src/flac/flacTag.ts
+++ b/src/flac/flacTag.ts
@@ -6,7 +6,7 @@ import XiphComment from "../xiph/xiphComment";
 import XiphPicture from "../xiph/xiphPicture";
 import {IPicture} from "../iPicture";
 import {Tag, TagTypes} from "../tag";
-import {Guards} from "../utils";
+import {Guards, NumberUtils} from "../utils";
 
 /**
  * Collection of tags that can be stored in a FLAC file.
@@ -85,10 +85,10 @@ export default class FlacTag extends CombinedTag {
 
     /** @inheritDoc */
     public removeTags(tagTypes: TagTypes): void {
-        if ((tagTypes & TagTypes.Xiph) !== 0) {
+        if (NumberUtils.hasFlag(tagTypes, TagTypes.Xiph)) {
             this._xiphComment = undefined;
         }
-        if ((tagTypes & TagTypes.FlacPictures) !== 0) {
+        if (NumberUtils.hasFlag(tagTypes, TagTypes.FlacPictures)) {
             this._pictures.splice(0, this._pictures.length);
         }
 

--- a/src/id3v2/frames/frameFactory.ts
+++ b/src/id3v2/frames/frameFactory.ts
@@ -19,7 +19,7 @@ import {RelativeVolumeFrame} from "./relativeVolumeFrame";
 import {SynchronizedLyricsFrame} from "./synchronizedLyricsFrame";
 import {TextInformationFrame, UserTextInformationFrame} from "./textInformationFrame";
 import {UrlLinkFrame, UserUrlLinkFrame} from "./urlLinkFrame";
-import {Guards} from "../../utils";
+import {Guards, NumberUtils} from "../../utils";
 
 export type FrameCreator = (data: ByteVector, offset: number, header: Id3v2FrameHeader, version: number) => Frame;
 
@@ -109,12 +109,12 @@ export default {
         }
 
         // TODO: Support compression
-        if ((header.flags & Id3v2FrameFlags.Compression) !== 0) {
+        if (NumberUtils.hasFlag(header.flags, Id3v2FrameFlags.Compression)) {
             throw new NotImplementedError("Compression is not supported");
         }
 
         // TODO: Support encryption
-        if ((header.flags & Id3v2FrameFlags.Encryption) !== 0) {
+        if (NumberUtils.hasFlag(header.flags, Id3v2FrameFlags.Encryption)) {
             throw new NotImplementedError("Encryption is not supported");
         }
 

--- a/src/id3v2/id3v2TagFooter.ts
+++ b/src/id3v2/id3v2TagFooter.ts
@@ -3,7 +3,7 @@ import SyncData from "./syncData";
 import {ByteVector} from "../byteVector";
 import {CorruptFileError} from "../errors";
 import {Id3v2TagHeader, Id3v2TagHeaderFlags} from "./id3v2TagHeader";
-import {Guards} from "../utils";
+import {Guards, NumberUtils} from "../utils";
 
 export default class Id3v2TagFooter {
     private static readonly _fileIdentifier: ByteVector = ByteVector.fromString("3DI", undefined, undefined, true);
@@ -31,13 +31,13 @@ export default class Id3v2TagFooter {
         footer._flags = data.get(5);
 
         // TODO: Is there any point to supporting footers on versions less than 4?
-        if (footer._majorVersion === 2 && (footer._flags & 127) !== 0) {
+        if (footer._majorVersion === 2 && NumberUtils.hasFlag(footer._flags, 127)) {
             throw new CorruptFileError("Invalid flags set on version 2 tag");
         }
-        if (footer._majorVersion === 3 && (footer._flags & 15) !== 0) {
+        if (footer._majorVersion === 3 && NumberUtils.hasFlag(footer._flags, 15)) {
             throw new CorruptFileError("Invalid flags set on version 3 tag");
         }
-        if (footer._majorVersion === 4 && (footer._flags & 7) !== 0) {
+        if (footer._majorVersion === 4 && NumberUtils.hasFlag(footer._flags, 7)) {
             throw new CorruptFileError("Invalid flags set on version 4 tag");
         }
 

--- a/src/id3v2/id3v2TagFooter.ts
+++ b/src/id3v2/id3v2TagFooter.ts
@@ -95,11 +95,11 @@ export default class Id3v2TagFooter {
      */
     public set flags(value: Id3v2TagHeaderFlags) {
         const version3Flags = Id3v2TagHeaderFlags.ExtendedHeader | Id3v2TagHeaderFlags.ExperimentalIndicator;
-        if ((value & version3Flags) !== 0 && this.majorVersion < 3) {
+        if (NumberUtils.hasFlag(value, version3Flags) && this.majorVersion < 3) {
             throw new Error("Feature only supported in version 2.3+");
         }
         const version4Flags = Id3v2TagHeaderFlags.FooterPresent;
-        if ((value & version4Flags) !== 0 && this.majorVersion < 4) {
+        if (NumberUtils.hasFlag(value, version4Flags) && this.majorVersion < 4) {
             throw new Error("Feature only supported in version 2.4+");
         }
 
@@ -157,7 +157,7 @@ export default class Id3v2TagFooter {
      */
     public set tagSize(value: number) {
         Guards.uint(value, "value");
-        if ((value & 0xF0000000) !== 0) {
+        if (NumberUtils.hasFlag(value, 0xF0000000)) {
             throw new Error("Argument out of range: value must be a 28-bit unsigned integer");
         }
 

--- a/src/id3v2/id3v2TagHeader.ts
+++ b/src/id3v2/id3v2TagHeader.ts
@@ -95,7 +95,7 @@ export class Id3v2TagHeader {
      * and footer.
      */
     public get completeTagSize(): number {
-        return (this._flags & Id3v2TagHeaderFlags.FooterPresent) > 0
+        return NumberUtils.hasFlag(this._flags, Id3v2TagHeaderFlags.FooterPresent)
             ? this.tagSize + Id3v2Settings.headerSize + Id3v2Settings.footerSize
             : this.tagSize + Id3v2Settings.headerSize;
     }
@@ -112,11 +112,11 @@ export class Id3v2TagHeader {
     public set flags(value: Id3v2TagHeaderFlags) {
         // @TODO: Does it make sense to check for flags for major version <4?
         const version3Flags = Id3v2TagHeaderFlags.ExtendedHeader | Id3v2TagHeaderFlags.ExperimentalIndicator;
-        if ((value & version3Flags) !== 0 && this.majorVersion < 3) {
+        if (NumberUtils.hasFlag(value, version3Flags) && this.majorVersion < 3) {
             throw new Error("Feature only supported in version 2.3+");
         }
         const version4Flags = Id3v2TagHeaderFlags.FooterPresent;
-        if ((value & version4Flags) !== 0 && this.majorVersion < 4) {
+        if (NumberUtils.hasFlag(value, version4Flags) && this.majorVersion < 4) {
             throw new Error("Feature only supported in version 2.4+");
         }
 
@@ -181,7 +181,7 @@ export class Id3v2TagHeader {
      */
     public set tagSize(value: number) {
         Guards.uint(value, "value");
-        if ((value & 0xF0000000) !== 0) {
+        if (NumberUtils.hasFlag(value, 0xF0000000)) {
             throw new Error("Argument out of range: value must be a 28-bit unsigned integer");
         }
 

--- a/src/id3v2/id3v2TagHeader.ts
+++ b/src/id3v2/id3v2TagHeader.ts
@@ -2,7 +2,7 @@ import Id3v2Settings from "./id3v2Settings";
 import SyncData from "./syncData";
 import {ByteVector, StringType} from "../byteVector";
 import {CorruptFileError} from "../errors";
-import {Guards} from "../utils";
+import {Guards, NumberUtils} from "../utils";
 
 export enum Id3v2TagHeaderFlags {
     /**
@@ -62,13 +62,13 @@ export class Id3v2TagHeader {
         header._flags = data.get(5);
 
         // Make sure flags provided are legal
-        if (header._majorVersion === 2 && (header._flags & 63) !== 0) {
+        if (header._majorVersion === 2 && NumberUtils.hasFlag(header._flags, 63)) {
             throw new CorruptFileError("Invalid flags set on version 2 tag");
         }
-        if (header._majorVersion === 3 && (header._flags & 15) !== 0) {
+        if (header._majorVersion === 3 && NumberUtils.hasFlag(header._flags, 15)) {
             throw new CorruptFileError("Invalid flags set on version 3 tag");
         }
-        if (header._majorVersion === 4 && (header._flags & 7) !== 0) {
+        if (header._majorVersion === 4 && NumberUtils.hasFlag(header._flags, 7)) {
             throw new CorruptFileError("Invalid flags set on version 4 tag");
         }
 

--- a/src/id3v2/syncData.ts
+++ b/src/id3v2/syncData.ts
@@ -1,5 +1,5 @@
 import {ByteVector} from "../byteVector";
-import {Guards} from "../utils";
+import {Guards, NumberUtils} from "../utils";
 
 /**
  * Support for encoding and decoding unsynchronized data and numbers.
@@ -22,7 +22,7 @@ export default {
 
         const out = ByteVector.fromSize(4, 0);
         for (let i = 0; i < 4; i++) {
-            out.set(i, value >> ((3 - i) * 7) & 0x7F);
+            out.set(i, NumberUtils.uintAnd(NumberUtils.uintRShift(value, (3 - i) * 7), 0x7F));
         }
 
         return out;
@@ -87,7 +87,7 @@ export default {
         Guards.notNullOrUndefined(data, "data");
 
         for (let i = data.length - 2; i >= 0; i--) {
-            if (data.get(i) === 0xFF && (data.get(i + 1) === 0 || (data.get(i + 1) & 0xE0) !== 0)) {
+            if (data.get(i) === 0xFF && (data.get(i + 1) === 0 || NumberUtils.hasFlag(data.get(i + 1), 0xE0))) {
                 data.insertByte(i + 1, 0x0);
             }
         }

--- a/src/mpeg/mpegAudioFile.ts
+++ b/src/mpeg/mpegAudioFile.ts
@@ -6,6 +6,7 @@ import {CorruptFileError} from "../errors";
 import {File, ReadStyle} from "../file";
 import {IFileAbstraction} from "../fileAbstraction";
 import {TagTypes} from "../tag";
+import {NumberUtils} from "../utils";
 
 /**
  * This class extends {@link SandwichFile} to provide tagging and properties support for
@@ -29,7 +30,7 @@ export default class MpegAudioFile extends SandwichFile {
     }
 
     protected readProperties(readStyle: ReadStyle): Properties {
-        if ((readStyle & ReadStyle.Average) === 0) {
+        if (!NumberUtils.hasFlag(readStyle, ReadStyle.Average)) {
             return undefined;
         }
 

--- a/src/mpeg/mpegAudioHeader.ts
+++ b/src/mpeg/mpegAudioHeader.ts
@@ -5,13 +5,15 @@ import {CorruptFileError} from "../errors";
 import {File} from "../file";
 import {IAudioCodec, MediaTypes} from "../iCodec";
 import {ChannelMode, MpegVersion} from "./mpegEnums";
-import {Guards} from "../utils";
+import {Guards, NumberUtils} from "../utils";
 
 /**
  * Provides information about an MPEG audio stream. For more information and definition of the
  * header, see http://www.mpgedit.org/mpgedit/mpeg_format/mpeghdr.htm
  */
 export default class MpegAudioHeader implements IAudioCodec {
+    // @TODO: make an enum for header flags
+
     public static readonly Unknown: MpegAudioHeader = MpegAudioHeader.fromInfo(
         0,
         0,
@@ -158,7 +160,7 @@ export default class MpegAudioHeader implements IAudioCodec {
 
         const index1 = this.version === MpegVersion.Version1 ? 0 : 1;
         const index2 = this.audioLayer - 1;
-        const index3 = (this._flags >> 12) & 0x0f;
+        const index3 = NumberUtils.uintAnd(NumberUtils.uintRShift(this._flags, 12), 0x0f);
         return MpegAudioHeader.bitrates[index1][index2][index3];
     }
 
@@ -186,7 +188,7 @@ export default class MpegAudioHeader implements IAudioCodec {
      * Gets the MPEG audio layer used to encode the audio represented by the current instance.
      */
     public get audioLayer(): number {
-        switch ((this._flags >> 17) & 0x03) {
+        switch (NumberUtils.uintAnd(NumberUtils.uintRShift(this._flags, 17), 0x03)) {
             case 1:
                 return 3;
             case 2:
@@ -199,7 +201,7 @@ export default class MpegAudioHeader implements IAudioCodec {
     /** @inheritDoc IAudioCodec.audioSampleRate */
     public get audioSampleRate(): number {
         const index1 = this.version;
-        const index2 = (this._flags >> 10) & 0x03;
+        const index2 = NumberUtils.uintAnd(NumberUtils.uintRShift(this._flags, 10), 0x03);
         return MpegAudioHeader.sampleRates[index1][index2];
     }
 

--- a/src/mpeg/mpegAudioHeader.ts
+++ b/src/mpeg/mpegAudioHeader.ts
@@ -208,7 +208,7 @@ export default class MpegAudioHeader implements IAudioCodec {
     /**
      * Gets the MPEG audio channel mode of the audio represented by the current instance.
      */
-    public get channelMode(): ChannelMode { return (this._flags >> 6) & 0x03; }
+    public get channelMode(): ChannelMode { return NumberUtils.uintAnd(NumberUtils.uintRShift(this._flags, 6), 0x03); }
 
     /** @inheritDoc ICodec.description */
     public get description(): string {
@@ -259,6 +259,8 @@ export default class MpegAudioHeader implements IAudioCodec {
 
         return this._durationMilliseconds;
     }
+
+    // TODO: Introduce an MPEG flags enum
 
     /**
      * Whether or not the current audio is copyrighted.
@@ -391,15 +393,15 @@ export default class MpegAudioHeader implements IAudioCodec {
         // - Bits 4 and 5 can be 00, 10, or 11 but not 01
         // - One or more of bits 6 and 7 must be set
         // - Bit 8 can be anything
-        if ((data.get(1) & 0xE6) <= 0xE0 || (data.get(1) & 0x18) === 0x08) {
+        if (NumberUtils.uintAnd(data.get(1), 0xE6) <= 0xE0 || NumberUtils.uintAnd(data.get(1), 0x18) === 0x08) {
             return "Second byte did not match MPEG sync";
         }
 
         const flags = data.toUint();
-        if (((flags >> 12) & 0x0F) === 0x0F) {
+        if (NumberUtils.hasFlag(NumberUtils.uintRShift(flags, 12), 0x0F, true)) {
             return "Header uses invalid bitrate index";
         }
-        if (((flags >> 10) & 0x03) === 0x03) {
+        if (NumberUtils.hasFlag(NumberUtils.uintRShift(flags, 10), 0x03, true)) {
             return "Invalid sample rate";
         }
 

--- a/src/mpeg/mpegVideoHeader.ts
+++ b/src/mpeg/mpegVideoHeader.ts
@@ -1,7 +1,7 @@
 import {CorruptFileError} from "../errors";
 import {File} from "../file";
 import {IVideoCodec, MediaTypes} from "../iCodec";
-import {Guards} from "../utils";
+import {Guards, NumberUtils} from "../utils";
 
 /**
  * Provides information about an MPEG video stream.
@@ -34,9 +34,9 @@ export default class MpegVideoHeader implements IVideoCodec {
         }
 
         this._videoWidth = data.mid(0, 2).toUShort() >>> 4;
-        this._videoHeight = (data.mid(1, 2).toShort() & 0x0FFF) >>> 0;
-        this._frameRateIndex = (data.get(3) & 0x0F) >>> 0;
-        this._videoBitrate = ((data.mid(4, 3).toUint() >>> 6) & 0x3FFFF) >>> 0;
+        this._videoHeight = NumberUtils.uintAnd(data.mid(1, 2).toShort(), 0x0FFF);
+        this._frameRateIndex = NumberUtils.uintAnd(data.get(3), 0x0F);
+        this._videoBitrate = NumberUtils.uintAnd(NumberUtils.uintRShift(data.mid(4, 3).toUint(), 6), 0x3FFFF);
     }
 
     // #region

--- a/src/mpeg/xingHeader.ts
+++ b/src/mpeg/xingHeader.ts
@@ -1,7 +1,7 @@
 import {ByteVector} from "../byteVector";
 import {CorruptFileError} from "../errors";
 import {ChannelMode, MpegVersion} from "./mpegEnums";
-import {Guards} from "../utils";
+import {Guards, NumberUtils} from "../utils";
 
 /**
  * Information about a variable bitrate MPEG audio stream
@@ -56,14 +56,14 @@ export default class XingHeader {
         const header = new XingHeader();
         let position = 8;
 
-        if ((data.get(7) & 0x01) !== 0) {
+        if (NumberUtils.hasFlag(data.get(7), 0x01)) {
             header._totalFrames = data.mid(position, 4).toUint();
             position += 4;
         } else {
             header._totalFrames = 0;
         }
 
-        if ((data.get(7) & 0x02) !== 0) {
+        if (NumberUtils.hasFlag(data.get(7), 0x02)) {
             header._totalSize = data.mid(position, 4).toUint();
         } else {
             header._totalSize = 0;

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -1,4 +1,5 @@
 import {IAudioCodec, ICodec, ILosslessAudioCodec, IPhotoCodec, IVideoCodec, MediaTypes} from "./iCodec";
+import {NumberUtils} from "./utils";
 
 
 export default class Properties implements ILosslessAudioCodec, IVideoCodec, IPhotoCodec {
@@ -148,7 +149,7 @@ export default class Properties implements ILosslessAudioCodec, IVideoCodec, IPh
         property: (codec: TCodec) => number,
         defaultValue: number
     ): number {
-        const codec = this._codecs.find((e) => !!e && (e.mediaTypes & mediaType) !== 0);
+        const codec = this._codecs.find((e) => !!e && NumberUtils.hasFlag(e.mediaTypes, mediaType));
         return codec ? property(<TCodec> codec) : defaultValue;
     }
 

--- a/src/riff/riffFile.ts
+++ b/src/riff/riffFile.ts
@@ -18,6 +18,7 @@ import {File, FileAccessMode, ReadStyle} from "../file";
 import {IFileAbstraction} from "../fileAbstraction";
 import {ICodec} from "../iCodec";
 import {Tag, TagTypes} from "../tag";
+import {NumberUtils} from "../utils";
 
 /**
  * This class extends {@link File} to provide tagging and properties support for RIFF files. These
@@ -70,7 +71,9 @@ export default class RiffFile extends File {
         //    complete tag information.
         const allTagTypes = [TagTypes.Id3v2, TagTypes.DivX, TagTypes.RiffInfo, TagTypes.MovieId];
         for (const tagType of allTagTypes) {
-            if ((defaultTags & tagType) === 0 || (this._tag.tagTypes & tagType) !== 0) {
+            const isDefault = NumberUtils.hasFlag(defaultTags, tagType);
+            const existsAlready = NumberUtils.hasFlag(this._tag.tagTypes, tagType);
+            if (!isDefault || existsAlready) {
                 continue;
             }
 
@@ -343,7 +346,7 @@ export default class RiffFile extends File {
     }
 
     private readProperties(readStyle: ReadStyle): Properties {
-        if ((readStyle & ReadStyle.Average) === 0) {
+        if (!NumberUtils.hasFlag(readStyle, ReadStyle.Average)) {
             return;
         }
 

--- a/src/sandwich/sandwichFile.ts
+++ b/src/sandwich/sandwichFile.ts
@@ -6,6 +6,7 @@ import StartTag from "./startTag";
 import {File, FileAccessMode, ReadStyle} from "../file";
 import {IFileAbstraction} from "../fileAbstraction";
 import {Tag, TagTypes} from "../tag";
+import {NumberUtils} from "../utils";
 
 export interface ISandwichFile {
     readonly mediaEndPosition: number;
@@ -48,8 +49,10 @@ export default abstract class SandwichFile extends File implements ISandwichFile
 
         // Create the default tags
         for (const tagType of defaultTagMappingTable.keys()) {
-            // Don't create tag if its not desired or already exists
-            if ((defaultTags & tagType) === 0 || (this._tag.tagTypes & tagType) !== 0) {
+            // Don't create tag if it's not desired or already exists
+            const isDefault = NumberUtils.hasFlag(defaultTags, tagType);
+            const existsAlready = NumberUtils.hasFlag(this._tag.tagTypes, tagType);
+            if (!isDefault || existsAlready) {
                 continue;
             }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -170,6 +170,10 @@ export class NumberUtils {
         return result;
     }
 
+    public static hasFlag(haystack: number, needle: number): boolean {
+        return (haystack & needle) !== 0;
+    }
+
     /**
      * Performs the same operation as ldexp does in C/C++
      * @param x Number to be multiplied by 2^y
@@ -203,12 +207,11 @@ export class NumberUtils {
 
     /**
      * Provides way to do unsigned bitwise OR without all the mess of parenthesis.
-     * @param x Left operand
-     * @param y Right operand
-     * @returns Number (x | y) >>> 0
+     * @param numbers Operands to bitwise or together
+     * @returns Number (x | y | ...) >>> 0
      */
-    public static uintOr(x: number, y: number): number {
-        return (x | y) >>> 0;
+    public static uintOr(... numbers: number[]): number {
+        return numbers.reduce((acc, cur) => (acc | cur) >>> 0, 0);
     }
 
     /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -170,8 +170,10 @@ export class NumberUtils {
         return result;
     }
 
-    public static hasFlag(haystack: number, needle: number): boolean {
-        return (haystack & needle) !== 0;
+    public static hasFlag(haystack: number, needle: number, strict: boolean = false): boolean {
+        return strict
+            ? (haystack & needle) === needle
+            : (haystack & needle) !== 0;
     }
 
     /**
@@ -231,6 +233,16 @@ export class NumberUtils {
      */
     public static uintRShift(x: number, y: number): number {
         return x >>> y;
+    }
+
+    /**
+     * Provides way to do unsigned bitwise XOR without all the mess of parenthesis.
+     * @param x Left operand
+     * @param y Right operand
+     * @returns Number (x ^ y) >>> 0
+     */
+    public static uintXor(x: number, y: number): number {
+        return (x ^ y) >>> 0;
     }
 
     /**

--- a/test-integration/utilities/standardFileTests.ts
+++ b/test-integration/utilities/standardFileTests.ts
@@ -14,6 +14,7 @@ import {
     Tag,
     TagTypes
 } from "../../src";
+import {NumberUtils} from "../../src/utils";
 
 export enum TestTagLevel {
     Normal,
@@ -128,7 +129,7 @@ export class StandardFileTests {
             assert.strictEqual(pics.length, 3);
 
             // Lazy picture check
-            const isLazyTest = (readStyle & ReadStyle.PictureLazy) !== 0;
+            const isLazyTest = NumberUtils.hasFlag(readStyle, ReadStyle.PictureLazy);
             for (let i = 0; i < 3; i++) {
                 if (isLazyTest) {
                     assert.isFalse((<ILazy> <PictureLazy> pics[i]).isLoaded);

--- a/test-unit/flac/flacTagTests.ts
+++ b/test-unit/flac/flacTagTests.ts
@@ -5,12 +5,13 @@ import {It, Mock, Times} from "typemoq";
 import EndTag from "../../src/sandwich/endTag";
 import FlacFileSettings from "../../src/flac/flacFileSettings";
 import FlacTag from "../../src/flac/flacTag";
+import Id3v1Tag from "../../src/id3v1/id3v1Tag";
 import StartTag from "../../src/sandwich/startTag";
 import XiphComment from "../../src/xiph/xiphComment";
 import XiphPicture from "../../src/xiph/xiphPicture";
 import {TagTypes} from "../../src/tag";
 import {TagTesters, Testers} from "../utilities/testers";
-import {Id3v1Tag} from "../../src";
+import {NumberUtils} from "../../src/utils";
 
 @suite class Flac_TagTests {
     @test
@@ -105,7 +106,7 @@ import {Id3v1Tag} from "../../src";
         assert.isOk(output);
         assert.instanceOf(output, XiphComment);
         assert.include(tags.tag.tags, output);
-        assert.isOk(tags.tag.tagTypes & TagTypes.Xiph);
+        assert.isTrue(NumberUtils.hasFlag(tags.tag.tagTypes, TagTypes.Xiph));
         assert.strictEqual(tags.tag.xiphComment, output);
     }
 

--- a/test-unit/id3v2/frameFactoryTests.ts
+++ b/test-unit/id3v2/frameFactoryTests.ts
@@ -21,6 +21,7 @@ import {RelativeVolumeFrame} from "../../src/id3v2/frames/relativeVolumeFrame";
 import {TextInformationFrame, UserTextInformationFrame} from "../../src/id3v2/frames/textInformationFrame";
 import {SynchronizedLyricsFrame} from "../../src/id3v2/frames/synchronizedLyricsFrame";
 import {UrlLinkFrame, UserUrlLinkFrame} from "../../src/id3v2/frames/urlLinkFrame";
+import {NumberUtils} from "../../src/utils";
 import {SynchronizedTextType, TimestampFormat} from "../../src/id3v2/utilTypes";
 
 // Setup chai
@@ -74,7 +75,8 @@ const assert = Chai.assert;
         const data = ByteVector.concatenate(
             FrameIdentifiers.TXXX.render(4),
             0x00, 0x00, 0x00, 0x0A,
-            (Id3v2FrameFlags.Compression & 0xFF >> 16), (Id3v2FrameFlags.Compression & 0xFF)
+            NumberUtils.uintRShift(NumberUtils.uintAnd(Id3v2FrameFlags.Compression, 0xFF), 16),
+            NumberUtils.uintAnd(Id3v2FrameFlags.Compression, 0xFF)
         );
 
         // Act / Assert
@@ -87,7 +89,8 @@ const assert = Chai.assert;
         const data = ByteVector.concatenate(
             FrameIdentifiers.TXXX.render(4),
             0x00, 0x00, 0x00, 0x0A,
-            (Id3v2FrameFlags.Encryption & 0xFF >> 16), (Id3v2FrameFlags.Encryption & 0xFF)
+            NumberUtils.uintRShift(NumberUtils.uintAnd(Id3v2FrameFlags.Encryption, 0xFF), 16),
+            NumberUtils.uintAnd(Id3v2FrameFlags.Encryption, 0xFF)
         );
 
         // Act / Assert

--- a/test-unit/id3v2/tagHeaderTests.ts
+++ b/test-unit/id3v2/tagHeaderTests.ts
@@ -6,6 +6,7 @@ import TestConstants from "../testConstants";
 import {ByteVector} from "../../src/byteVector";
 import {Id3v2TagHeader, Id3v2TagHeaderFlags} from "../../src/id3v2/id3v2TagHeader";
 import {Testers} from "../utilities/testers";
+import {NumberUtils} from "../../src/utils";
 
 // Setup chai
 const assert = Chai.assert;
@@ -276,7 +277,7 @@ const getTestHeader = (majorVersion: number, minorVersion: number, flags: Id3v2T
 
         // Assert
         assert.equal(header.majorVersion, 2);
-        assert.equal(header.flags & flags, 0);
+        assert.isFalse(NumberUtils.hasFlag(header.flags, flags));
     }
 
     @test
@@ -290,7 +291,7 @@ const getTestHeader = (majorVersion: number, minorVersion: number, flags: Id3v2T
 
         // Assert
         assert.equal(header.majorVersion, 3);
-        assert.equal(header.flags & flags, 0);
+        assert.isFalse(NumberUtils.hasFlag(header.flags, flags));
     }
 
     @test

--- a/test-unit/sandwich/endTagTests.ts
+++ b/test-unit/sandwich/endTagTests.ts
@@ -12,6 +12,7 @@ import {File, ReadStyle} from "../../src/file";
 import {Id3v2TagHeaderFlags} from "../../src/id3v2/id3v2TagHeader";
 import {TagTypes} from "../../src/tag";
 import {TagTesters, Testers} from "../utilities/testers";
+import {NumberUtils} from "../../src/utils";
 
 @suite class Sandwich_EndTagTests {
     @test
@@ -209,7 +210,7 @@ import {TagTesters, Testers} from "../utilities/testers";
         assert.isOk(newTag);
         assert.strictEqual(newTag.tagTypes, TagTypes.Id3v2);
         assert.strictEqual((<Id3v2Tag> newTag).version, 4);
-        assert.notEqual((<Id3v2Tag> newTag).flags & Id3v2TagHeaderFlags.FooterPresent, 0);
+        assert.isTrue(NumberUtils.hasFlag((<Id3v2Tag> newTag).flags, Id3v2TagHeaderFlags.FooterPresent));
 
         assert.strictEqual(tag.tags.length, 1);
         assert.strictEqual(tag.tagTypes, TagTypes.Id3v2);


### PR DESCRIPTION
**Description**: Adding a new utility method to determine whether a number has a flag. This makes it a bit clearer what some bitwise logic is doing (and avoid making mistakes because of JavaScript's obnoxious treatment of number as signed in most cases).

**Testing**: Unit and integration tests are still passing