### PR TITLE
Standardize on "unsynchronize" for ID3v2

### DIFF
--- a/src/id3v2/frames/frame.ts
+++ b/src/id3v2/frames/frame.ts
@@ -141,7 +141,7 @@ export abstract class Frame {
 
         // Remove flags that are not supported by older versions of ID3v2
         if (version < 4) {
-            const v4Flags = Id3v2FrameFlags.DataLengthIndicator | Id3v2FrameFlags.Desynchronized;
+            const v4Flags = Id3v2FrameFlags.DataLengthIndicator | Id3v2FrameFlags.Unsynchronized;
             this.flags &= ~(v4Flags);
         }
         if (version < 3) {
@@ -180,7 +180,7 @@ export abstract class Frame {
         if (NumberUtils.hasFlag(this.flags, Id3v2FrameFlags.Encryption)) {
             throw new NotImplementedError("Encryption is not yet supported");
         }
-        if (NumberUtils.hasFlag(this.flags, Id3v2FrameFlags.Desynchronized)) {
+        if (NumberUtils.hasFlag(this.flags, Id3v2FrameFlags.Unsynchronized)) {
             fieldData = SyncData.unsyncByteVector(fieldData);
         }
 
@@ -267,7 +267,7 @@ export abstract class Frame {
         }
 
         let data = frameData.subarray(dataOffset, dataLength);
-        if (NumberUtils.hasFlag(this.flags, Id3v2FrameFlags.Desynchronized)) {
+        if (NumberUtils.hasFlag(this.flags, Id3v2FrameFlags.Unsynchronized)) {
             data = SyncData.resyncByteVector(data);
         }
 

--- a/src/id3v2/frames/frameFactory.ts
+++ b/src/id3v2/frames/frameFactory.ts
@@ -103,9 +103,8 @@ export default {
         // Illegal frames are filtered out when creating the frame header
 
         // Mark the frame as unsynchronized if the entire tag is already unsynchronized
-        // @TODO Standardize on "Desynchronized"
         if (alreadyUnsynced) {
-            header.flags &= ~Id3v2FrameFlags.Desynchronized;
+            header.flags &= ~Id3v2FrameFlags.Unsynchronized;
         }
 
         // TODO: Support compression

--- a/src/id3v2/frames/frameHeader.ts
+++ b/src/id3v2/frames/frameHeader.ts
@@ -41,9 +41,9 @@ export enum Id3v2FrameFlags {
     Encryption = 0x0004,
 
     /**
-     * Frame data has been desynchronized.
+     * Frame data has been unsynchronized using the ID3v2 unsynchronization scheme.
      */
-    Desynchronized = 0x0002,
+    Unsynchronized = 0x0002,
 
     /**
      * Frame has a data length indicator.

--- a/src/id3v2/id3v2Tag.ts
+++ b/src/id3v2/id3v2Tag.ts
@@ -928,7 +928,7 @@ export default class Id3v2Tag extends Tag {
         // Loop through the frames rendering them and adding them to tag data
         const renderedFrames = this._frameList.map((frame) => {
             if (unsyncAtFrameLevel) {
-                frame.flags |= Id3v2FrameFlags.Desynchronized;
+                frame.flags |= Id3v2FrameFlags.Unsynchronized;
             }
             if ((frame.flags & Id3v2FrameFlags.TagAlterPreservation) !== 0 ) {
                 return undefined;

--- a/src/id3v2/id3v2TagHeader.ts
+++ b/src/id3v2/id3v2TagHeader.ts
@@ -26,7 +26,8 @@ export enum Id3v2TagHeaderFlags {
     ExtendedHeader = 0x40,
 
     /**
-     * The tag described by the header has been desynchronized.
+     * The tag described by the header has been unsynchronized using the ID3v2 unsynchronization
+     * scheme.
      */
     Unsynchronization = 0x80,
 }

--- a/test-unit/id3v2/frameTests.ts
+++ b/test-unit/id3v2/frameTests.ts
@@ -185,7 +185,7 @@ class TestFrame extends Frame {
         // Arrange
         let fieldData = SyncData.unsyncByteVector(TestFrame.renderFieldData);
 
-        const header = new Id3v2FrameHeader(FrameIdentifiers.TXXX, Id3v2FrameFlags.Desynchronized);
+        const header = new Id3v2FrameHeader(FrameIdentifiers.TXXX, Id3v2FrameFlags.Unsynchronized);
         header.frameSize = fieldData.length;
         const frame = new TestFrame(header);
         const data = ByteVector.concatenate(

--- a/test-unit/id3v2/id3v2TagTests.ts
+++ b/test-unit/id3v2/id3v2TagTests.ts
@@ -1870,8 +1870,8 @@ function getTestTagHeader(version: number, flags: Id3v2TagHeaderFlags, tagSize: 
         const output = tag.render();
 
         // Assert
-        frame1.flags |= Id3v2FrameFlags.Desynchronized;
-        frame2.flags |= Id3v2FrameFlags.Desynchronized;
+        frame1.flags |= Id3v2FrameFlags.Unsynchronized;
+        frame2.flags |= Id3v2FrameFlags.Unsynchronized;
         const frame1Data = frame1.render(4);
         const frame2Data = frame2.render(4);
 


### PR DESCRIPTION
The ID3v2 standard calls this "unsynchronize," so it's probably a safe bet to call it that here. Now that I understand the purpose of the mechanism (ie, modify MPEG synchronization bytes that occur in the tag data so that bad MPEG decoders don't try to read tag bytes as media), I think the name makes more sense than the more correct word "desynchronize".