### PR TITLE
Testers: Change allowUndefined to an Allow enum

### DIFF
--- a/test-unit/aac/aacAudioHeaderTests.ts
+++ b/test-unit/aac/aacAudioHeaderTests.ts
@@ -8,7 +8,7 @@ import TestFile from "../utilities/testFile";
 import {ByteVector} from "../../src/byteVector";
 import {File} from "../../src/file";
 import {MediaTypes} from "../../src/properties";
-import {Testers} from "../utilities/testers";
+import {Allow, Testers} from "../utilities/testers";
 
 // Test constants
 const sampleHeaderBytes = ByteVector.fromByteArray(new Uint8Array([0xFF, 0xF5, 0x55, 0x55, 0x55, 0x55, 0x55]));
@@ -71,7 +71,7 @@ class Aac_AudioHeaderTests {
         // Act / Assert
         Testers.testTruthy((v: File) => { AacAudioHeader.find(v, 0, 0); });
         Testers.testUint((v: number) => { AacAudioHeader.find(mockFile.object, v, 0); });
-        Testers.testUint((v: number) => { AacAudioHeader.find(mockFile.object, 0, v); }, true);
+        Testers.testUint((v: number) => { AacAudioHeader.find(mockFile.object, 0, v); }, Allow.Undefined);
     }
 
     @test

--- a/test-unit/byteVectorConstructorTests.ts
+++ b/test-unit/byteVectorConstructorTests.ts
@@ -9,7 +9,7 @@ import TestStream from "./utilities/testStream";
 import {ByteVector, Encoding, StringType} from "../src/byteVector";
 import {IFileAbstraction} from "../src/fileAbstraction";
 import {IStream} from "../src/stream";
-import {Testers} from "./utilities/testers";
+import {Allow, Testers} from "./utilities/testers";
 
 // Setup chai
 Chai.use(ChaiAsPromised);
@@ -167,7 +167,7 @@ const assert = Chai.assert;
 
         // Act / Assert
         Testers.testTruthy((v: Uint8Array) => ByteVector.fromByteArray(v, 123));
-        Testers.testSafeUint((v) => ByteVector.fromByteArray(bytes, v), true);
+        Testers.testSafeUint((v) => ByteVector.fromByteArray(bytes, v), Allow.Undefined);
         assert.throws(() => ByteVector.fromByteArray(bytes, 123));
     }
 
@@ -1165,7 +1165,7 @@ const assert = Chai.assert;
     @test
     public fromString_invalidLength() {
         // Arrange, Act, Assert
-        Testers.testSafeUint((v: number) => { ByteVector.fromString("", undefined, v); }, true);
+        Testers.testSafeUint((v: number) => { ByteVector.fromString("", undefined, v); }, Allow.Undefined);
     }
 
     @test

--- a/test-unit/byteVectorMethodTests.ts
+++ b/test-unit/byteVectorMethodTests.ts
@@ -2,7 +2,7 @@ import * as Chai from "chai";
 import {suite, test} from "@testdeck/mocha";
 
 import {ByteVector, StringType} from "../src/byteVector";
-import {Testers} from "./utilities/testers";
+import {Allow, Testers} from "./utilities/testers";
 
 // Setup chai
 const assert = Chai.assert;
@@ -493,7 +493,7 @@ const assert = Chai.assert;
 
         // Act / Assert
         Testers.testTruthy((v: ByteVector) => { bv.containsAt(v, 0); });
-        Testers.testSafeInt((v: number) => { bv.containsAt(pattern, v); }, true);
+        Testers.testSafeInt((v: number) => { bv.containsAt(pattern, v); }, Allow.Undefined);
     }
 
     @test
@@ -1040,7 +1040,7 @@ const assert = Chai.assert;
 
         // Act / Assert
         Testers.testTruthy((v: ByteVector) => { bv.find(v, 1); });
-        Testers.testUint((v: number) => { bv.find(pattern, v); }, true);
+        Testers.testUint((v: number) => { bv.find(pattern, v); }, Allow.Undefined);
         assert.throws(() => { bv.find(pattern, 0); });
     }
 
@@ -1286,7 +1286,7 @@ const assert = Chai.assert;
         // Act / Assert
         Testers.testTruthy((v: ByteVector) => bv.offsetFind(v, 1));
         Testers.testSafeUint((v) => bv.offsetFind(pattern, v));
-        Testers.testUint((v) => bv.offsetFind(pattern, 0, v), true);
+        Testers.testUint((v) => bv.offsetFind(pattern, 0, v), Allow.Undefined);
         assert.throws(() => bv.offsetFind(pattern, 0, 0));
     }
 
@@ -1553,7 +1553,7 @@ const assert = Chai.assert;
 
         // Act / Assert
         Testers.testTruthy((v: ByteVector) => bv.rFind(v, 1));
-        Testers.testUint((v: number) => bv.rFind(pattern, v), true);
+        Testers.testUint((v: number) => bv.rFind(pattern, v), Allow.Undefined);
         assert.throws(() => bv.rFind(pattern, 0));
     }
 
@@ -2146,8 +2146,8 @@ const assert = Chai.assert;
 
         // Act / Assert
         Testers.testTruthy((v: ByteVector) => { bv.split(v); });
-        Testers.testUint((v: number) => { bv.split(pattern, v); }, true);
-        Testers.testUint((v: number) => { bv.split(pattern, 1, v); }, true);
+        Testers.testUint((v: number) => { bv.split(pattern, v); }, Allow.Undefined);
+        Testers.testUint((v: number) => { bv.split(pattern, 1, v); }, Allow.Undefined);
         assert.throws(() => bv.split(pattern, 0));
     }
 
@@ -2458,7 +2458,7 @@ const assert = Chai.assert;
 
         // Act / Assert
         Testers.testSafeUint((v) => bv.subarray(v, 1));
-        Testers.testSafeUint((v) => bv.subarray(0, v), true);
+        Testers.testSafeUint((v) => bv.subarray(0, v), Allow.Undefined);
     }
 
     @test

--- a/test-unit/mpeg/mpegAudioHeaderTests.ts
+++ b/test-unit/mpeg/mpegAudioHeaderTests.ts
@@ -10,7 +10,7 @@ import {ByteVector} from "../../src/byteVector";
 import {File} from "../../src/file";
 import {MediaTypes} from "../../src/properties";
 import {ChannelMode, MpegVersion} from "../../src/mpeg/mpegEnums";
-import {Testers} from "../utilities/testers";
+import {Allow, Testers} from "../utilities/testers";
 
 @suite class Mpeg_AudioHeader_ConstructorTests {
     private mockFile = TypeMoq.Mock.ofType<File>().object;
@@ -670,7 +670,7 @@ import {Testers} from "../utilities/testers";
         // Act / Assert
         Testers.testTruthy((v: File) => { MpegAudioHeader.find(v, 123, 234); });
         Testers.testSafeInt((v: number) => { MpegAudioHeader.find(mockFile, v, 234); });
-        Testers.testSafeInt((v: number) => { MpegAudioHeader.find(mockFile, 123, v); }, true);
+        Testers.testSafeInt((v: number) => { MpegAudioHeader.find(mockFile, 123, v); }, Allow.Undefined);
     }
 
     @test

--- a/test-unit/pictureLazyTests.ts
+++ b/test-unit/pictureLazyTests.ts
@@ -6,7 +6,7 @@ import TestStream from "./utilities/testStream";
 import {IFileAbstraction} from "../src/fileAbstraction";
 import {ByteVector, StringType} from "../src/byteVector";
 import {PictureLazy, PictureType} from "../src/picture";
-import {Testers} from "./utilities/testers";
+import {Allow, Testers} from "./utilities/testers";
 
 // Setup chai
 const assert = Chai.assert;
@@ -65,7 +65,7 @@ const assert = Chai.assert;
         // Act / Assert
         Testers.testTruthy((v: IFileAbstraction) => { PictureLazy.fromFile(v, 0 , 0); });
         Testers.testInt((v: number) => { PictureLazy.fromFile(mockFile.object, v, 0); });
-        Testers.testInt((v: number) => { PictureLazy.fromFile(mockFile.object, v, 0); }, true);
+        Testers.testInt((v: number) => { PictureLazy.fromFile(mockFile.object, v, 0); }, Allow.Undefined);
     }
 
     @test

--- a/test-unit/utilities/testers.ts
+++ b/test-unit/utilities/testers.ts
@@ -3,6 +3,13 @@ import {IMock} from "typemoq";
 
 import {Tag} from "../../src/tag";
 import {ByteVector, StringType} from "../../src/byteVector";
+import {NumberUtils} from "../../src/utils";
+
+export enum Allow {
+    Nothing = 0,
+    Undefined = 1,
+    Null = 2
+}
 
 export class Testers {
     public static testByte(testFunc: (testValue: number) => void): void {
@@ -11,13 +18,16 @@ export class Testers {
         assert.throws(() => testFunc(0x100));
     }
 
-    public static testInt(testFunc: (testValue: number) => void, allowUndefined = false): void {
+    public static testInt(testFunc: (testValue: number) => void, allow: Allow = Allow.Nothing): void {
         assert.throws(() => testFunc(-2147483648 - 1));
         assert.throws(() => testFunc(1.23));
         assert.throws(() => testFunc(2147483647 + 1));
-        assert.throws(() => testFunc(null));
 
-        if (!allowUndefined) {
+        if (!NumberUtils.hasFlag(allow, Allow.Null)) {
+            assert.throws(() => testFunc(null));
+        }
+
+        if (!NumberUtils.hasFlag(allow, Allow.Undefined)) {
             assert.throws(() => testFunc(undefined));
         }
     }
@@ -27,24 +37,31 @@ export class Testers {
         assert.throws(() => testFunc(""));
     }
 
-    public static testSafeInt(testFunc: (testValue: number) => void, allowUndefined = false): void {
+    public static testSafeInt(testFunc: (testValue: number) => void, allow: Allow = Allow.Nothing): void {
         assert.throws(() => testFunc(Number.MIN_SAFE_INTEGER - 1));
         assert.throws(() => testFunc(1.23));
         assert.throws(() => testFunc(Number.MAX_SAFE_INTEGER + 1));
-        assert.throws(() => testFunc(null));
 
-        if (!allowUndefined) {
+        if (!NumberUtils.hasFlag(allow, Allow.Null)) {
+            assert.throws(() => testFunc(null));
+        }
+
+        if (!NumberUtils.hasFlag(allow, Allow.Undefined)) {
             assert.throws(() => testFunc(undefined));
         }
     }
 
-    public static testSafeUint(testFunc: (testValue: number) => void, allowUndefined = false): void {
+    public static testSafeUint(testFunc: (testValue: number) => void, allow: Allow = Allow.Nothing): void {
         assert.throws(() => testFunc(-1));
         assert.throws(() => testFunc(1.23));
         assert.throws(() => testFunc(Number.MAX_SAFE_INTEGER + 1));
-        assert.throws(() => testFunc(null));
 
-        if (!allowUndefined) {
+
+        if (!NumberUtils.hasFlag(allow, Allow.Null)) {
+            assert.throws(() => testFunc(null));
+        }
+
+        if (!NumberUtils.hasFlag(allow, Allow.Undefined)) {
             assert.throws(() => testFunc(undefined));
         }
     }
@@ -54,24 +71,30 @@ export class Testers {
         assert.throws(() => testFunc(null));
     }
 
-    public static testUint(testFunc: (testValue: number) => void, allowUndefined = false): void {
+    public static testUint(testFunc: (testValue: number) => void, allow: Allow = Allow.Nothing): void {
         assert.throws(() => testFunc(-1));
         assert.throws(() => testFunc(1.23));
         assert.throws(() => testFunc(0xFFFFFFFF + 1));
-        assert.throws(() => testFunc(null));
 
-        if (!allowUndefined) {
+        if (!NumberUtils.hasFlag(allow, Allow.Null)) {
+            assert.throws(() => testFunc(null));
+        }
+
+        if (!NumberUtils.hasFlag(allow, Allow.Undefined)) {
             assert.throws(() => testFunc(undefined));
         }
     }
 
-    public static testUlong(testFunc: (testValue: bigint) => void, allowUndefined = false): void {
+    public static testUlong(testFunc: (testValue: bigint) => void, allow: Allow = Allow.Nothing): void {
         assert.throws(() => testFunc(BigInt(-1)));
         assert.throws(() => testFunc(BigInt(1.23)));
         assert.throws(() => testFunc(BigInt("18446744073709551615") + BigInt(1)));
-        assert.throws(() => testFunc(null));
 
-        if (!allowUndefined) {
+        if (!NumberUtils.hasFlag(allow, Allow.Null)) {
+            assert.throws(() => testFunc(null));
+        }
+
+        if (!NumberUtils.hasFlag(allow, Allow.Undefined)) {
             assert.throws(() => testFunc(undefined));
         }
     }

--- a/test-unit/xiph/xiphCommentTests.ts
+++ b/test-unit/xiph/xiphCommentTests.ts
@@ -10,7 +10,7 @@ import XiphTestResources from "./resources";
 import {ByteVector, StringType} from "../../src/byteVector";
 import {IPicture, Picture, PictureType} from "../../src/picture";
 import {TagTypes} from "../../src/tag";
-import {TagTesters, Testers} from "../utilities/testers";
+import {Allow, TagTesters, Testers} from "../utilities/testers";
 
 @suite class Xiph_Comment_ConstructorTests {
     @test
@@ -1186,7 +1186,7 @@ import {TagTesters, Testers} from "../utilities/testers";
         // Act / Assert
         Testers.testString((v: string) => comment.setFieldAsUint(v, 0, 0));
         Testers.testUint((v) => comment.setFieldAsUint("qqq", v, 0));
-        Testers.testUint((v) => comment.setFieldAsUint("qqq", 0, v), true);
+        Testers.testUint((v) => comment.setFieldAsUint("qqq", 0, v), Allow.Undefined);
         assert.throws(() => comment.setFieldAsUint("COVERART", 0));
         assert.throws(() => comment.setFieldAsUint("METADATA_BLOCK_PICTURE", 0));
     }


### PR DESCRIPTION
**Description**: This PR changes the signature of various unit test utilities in `Testers` from having an explicit `allowUndefined` boolean to accepting an enum `Allow` that has bit flags for `Undefined` and `Null`. The testers have also been updated to conditionally turn on running the test with `null` if `Allow.Null` is in the flags, although this is not being used yet. 

**Testing**: All existing tests are passing