### PR TITLE
Change ogg page header granule position property to bytevector

### DIFF
--- a/src/ogg/codecs/iOggCodec.ts
+++ b/src/ogg/codecs/iOggCodec.ts
@@ -26,7 +26,7 @@ export default interface IOggCodec extends ICodec {
      * @param firstGranularPosition First granular position of the stream
      * @param lastGranularPosition Last granular position of the stream
      */
-    setDuration(firstGranularPosition: number, lastGranularPosition: number): void;
+    setDuration(firstGranularPosition: ByteVector, lastGranularPosition: ByteVector): void;
 
     /**
      * Renders and write the provided comment into the provided list of packets.

--- a/src/ogg/codecs/opus.ts
+++ b/src/ogg/codecs/opus.ts
@@ -2,7 +2,7 @@ import IOggCodec from "./iOggCodec";
 import XiphComment from "../../xiph/xiphComment";
 import {ByteVector, StringType} from "../../byteVector";
 import {IAudioCodec, MediaTypes} from "../../properties";
-import {Guards} from "../../utils";
+import {Guards, NumberUtils} from "../../utils";
 
 /**
  * Represents an Ogg Opus bitstream for use within an Ogg file.
@@ -135,8 +135,8 @@ export default class Opus implements IOggCodec, IAudioCodec {
 
         // NOTE: It probably looks wrong to use 48kHz all the time, but this is actually correct as
         //    per the Opus guide https://wiki.xiph.org/OpusFAQ
-        const durationSeconds = (lastLong - firstLong - BigInt(this._preSkip)) / BigInt(48000);
-        const durationMilliseconds = durationSeconds * BigInt(1000);
+        const durationNumerator = lastLong - firstLong - BigInt(this._preSkip);
+        const durationMilliseconds = durationNumerator * NumberUtils.BIG_ONE_THOUSAND / BigInt(48000)
 
         // NOTE: If milliseconds is greater than max safe integer, we can't reliably determine
         //    duration so return -1.

--- a/src/ogg/codecs/theora.ts
+++ b/src/ogg/codecs/theora.ts
@@ -129,8 +129,9 @@ export default class Theora implements IOggCodec, IVideoCodec {
         const iFrame = granuleNumber >> this._keyframeGranuleShift;
         const pFrame = granuleNumber - (iFrame << this._keyframeGranuleShift);
 
-        // Since bigint is an integer we multiply the fps by an extra 100 then divide it by 100. If
-        // this is not done, the fps will be 0.
-        return (iFrame + pFrame) * BigInt(Math.floor(this._fpsDenominator / this._fpsNumerator * 100000)) / BigInt(100);
+        // Since bigint is an integer we multiply the fps by an extra 10000 then divide it by
+        // 10000. If this is not done, the fps will be 0.
+        const fpsFactor = BigInt(Math.floor(this._fpsDenominator / this._fpsNumerator * 10000000))
+        return (iFrame + pFrame) * fpsFactor / BigInt(10000);
     }
 }

--- a/src/ogg/codecs/theora.ts
+++ b/src/ogg/codecs/theora.ts
@@ -21,7 +21,7 @@ export default class Theora implements IOggCodec, IVideoCodec {
     private readonly _fpsDenominator: number;
     private readonly _fpsNumerator: number;
     private readonly _height: number;
-    private readonly _keyframeGranuleShift: number;
+    private readonly _keyframeGranuleShift: bigint;
     private readonly _majorVersion: number;
     private readonly _minorVersion: number;
     private readonly _reversionVersion: number;
@@ -50,7 +50,7 @@ export default class Theora implements IOggCodec, IVideoCodec {
         this._fpsDenominator = headerPacket.subarray(26, 4).toUint();
 
         const lastBits = headerPacket.subarray(40, 2).toShort();
-        this._keyframeGranuleShift = NumberUtils.uintAnd(NumberUtils.uintRShift(lastBits, 5), 0x1F);
+        this._keyframeGranuleShift = BigInt(NumberUtils.uintAnd(NumberUtils.uintRShift(lastBits, 5), 0x1F));
     }
 
     /** @inheritDoc */
@@ -95,15 +95,15 @@ export default class Theora implements IOggCodec, IVideoCodec {
         Guards.truthy(firstGranularPosition, "firstGranularPosition");
         Guards.truthy(lastGranularPosition, "lastGranularPosition");
 
-        const durationSeconds = this.getGranuleTime(lastGranularPosition) - this.getGranuleTime(firstGranularPosition);
-        const durationMilliseconds = durationSeconds * BigInt(1000);
+        const durationMilli = this.getGranuleTime(lastGranularPosition) - this.getGranuleTime(firstGranularPosition);
+        // const durationMilliseconds = durationSeconds * BigInt(1000);
 
         // Note: if the duration is determined to be too big for safe int, just report it as
         //    unknown duration.
         // @TODO: Maybe expose this to the user for config?
-        this._durationMilliseconds = durationMilliseconds > Number.MAX_SAFE_INTEGER
+        this._durationMilliseconds = durationMilli > Number.MAX_SAFE_INTEGER
             ? 0
-            : Number(durationMilliseconds);
+            : Number(durationMilli);
     }
 
     /** @inheritDoc */
@@ -125,11 +125,12 @@ export default class Theora implements IOggCodec, IVideoCodec {
     }
 
     private getGranuleTime(granularPosition: ByteVector): bigint {
-        const iFrame = granularPosition.subarray(0, granularPosition.length - this._keyframeGranuleShift)
-            .toUlong(false);
-        const pFrame = granularPosition.subarray(this._keyframeGranuleShift)
-            .toUlong(false);
+        const granuleNumber = granularPosition.toUlong(false);
+        const iFrame = granuleNumber >> this._keyframeGranuleShift;
+        const pFrame = granuleNumber - (iFrame << this._keyframeGranuleShift);
 
-        return (iFrame + pFrame) * (BigInt(this._fpsDenominator) / BigInt(this._fpsNumerator));
+        // Since bigint is an integer we multiply the fps by an extra 100 then divide it by 100. If
+        // this is not done, the fps will be 0.
+        return (iFrame + pFrame) * BigInt(Math.floor(this._fpsDenominator / this._fpsNumerator * 100000)) / BigInt(100);
     }
 }

--- a/src/ogg/codecs/theora.ts
+++ b/src/ogg/codecs/theora.ts
@@ -91,9 +91,9 @@ export default class Theora implements IOggCodec, IVideoCodec {
     }
 
     /** @inheritDoc */
-    public setDuration(firstGranularPosition: number, lastGranularPosition: number): void {
-        Guards.safeUint(firstGranularPosition, "firstGranularPosition");
-        Guards.safeUint(lastGranularPosition, "lastGranularPosition");
+    public setDuration(firstGranularPosition: ByteVector, lastGranularPosition: ByteVector): void {
+        Guards.truthy(firstGranularPosition, "firstGranularPosition");
+        Guards.truthy(lastGranularPosition, "lastGranularPosition");
 
         const durationSeconds = this.getGranuleTime(lastGranularPosition) - this.getGranuleTime(firstGranularPosition);
         this._durationMilliseconds = durationSeconds * 1000;

--- a/src/ogg/codecs/vorbis.ts
+++ b/src/ogg/codecs/vorbis.ts
@@ -2,7 +2,7 @@ import IOggCodec from "./iOggCodec";
 import XiphComment from "../../xiph/xiphComment";
 import {ByteVector, StringType} from "../../byteVector";
 import {IAudioCodec, MediaTypes} from "../../properties";
-import {Guards} from "../../utils";
+import {Guards, NumberUtils} from "../../utils";
 
 /**
  * Types of packets that occur within an Ogg Vorbis bitstream.
@@ -114,14 +114,23 @@ export default class Vorbis implements IOggCodec, IAudioCodec {
     }
 
     /** @inheritDoc */
-    public setDuration(firstGranularPosition: number, lastGranularPosition: number): void {
-        Guards.safeUint(firstGranularPosition, "firstGranularPosition");
-        Guards.safeUint(lastGranularPosition, "lastGranularPosition");
+    public setDuration(firstGranularPosition: ByteVector, lastGranularPosition: ByteVector): void {
+        Guards.truthy(firstGranularPosition, "firstGranularPosition");
+        Guards.truthy(lastGranularPosition, "lastGranularPosition");
+
+        const firstLong = firstGranularPosition.toUlong(false);
+        const lastLong = lastGranularPosition.toUlong(false);
 
         const durationSeconds = this._sampleRate === 0
+            ? NumberUtils.BIG_ZERO
+            : (firstLong - lastLong) / BigInt(this._sampleRate);
+        const durationMilliseconds = durationSeconds * BigInt(1000);
+
+        // Note: if duration is > max safe, we cannot safely report the duration
+        // @TODO: Make this configurable by the user
+        this._durationMilliseconds = durationMilliseconds > Number.MAX_SAFE_INTEGER
             ? 0
-            : (lastGranularPosition - firstGranularPosition) / this._sampleRate;
-        this._durationMilliseconds = durationSeconds * 1000;
+            : Number(durationMilliseconds);
     }
 
     /** @inheritDoc */

--- a/src/ogg/codecs/vorbis.ts
+++ b/src/ogg/codecs/vorbis.ts
@@ -121,10 +121,9 @@ export default class Vorbis implements IOggCodec, IAudioCodec {
         const firstLong = firstGranularPosition.toUlong(false);
         const lastLong = lastGranularPosition.toUlong(false);
 
-        const durationSeconds = this._sampleRate === 0
+        const durationMilliseconds = this._sampleRate === 0
             ? NumberUtils.BIG_ZERO
-            : (firstLong - lastLong) / BigInt(this._sampleRate);
-        const durationMilliseconds = durationSeconds * BigInt(1000);
+            : ((lastLong - firstLong) * BigInt(1000)) / BigInt(this._sampleRate);
 
         // Note: if duration is > max safe, we cannot safely report the duration
         // @TODO: Make this configurable by the user

--- a/src/ogg/oggBitStream.ts
+++ b/src/ogg/oggBitStream.ts
@@ -11,7 +11,7 @@ import {OggPageFlags} from "./oggPageHeader";
  */
 export default class OggBitStream {
     private readonly _codec: IOggCodec;
-    private readonly _firstAbsoluteGranularPosition: number;
+    private readonly _firstAbsoluteGranularPosition: ByteVector;
     private _previousPacket: ByteVector;
 
     /**
@@ -75,9 +75,7 @@ export default class OggBitStream {
      * granular position of the stream.
      * @internal
      */
-    public setDuration(lastAbsoluteGranularPosition: number): void {
-        Guards.safeUint(lastAbsoluteGranularPosition, "lastAbsoluteGranularPosition");
-
+    public setDuration(lastAbsoluteGranularPosition: ByteVector): void {
         this._codec.setDuration(this._firstAbsoluteGranularPosition, lastAbsoluteGranularPosition);
     }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -168,6 +168,7 @@ export class NumberUtils {
     public static readonly BIG_ZERO = BigInt(0);
     public static readonly BIG_ONE = BigInt(1);
     public static readonly BIG_TWO = BigInt(2);
+    public static readonly BIG_ONE_THOUSAND = BigInt(1000);
     public static readonly TICKS_PER_MILLISECOND_BIG = BigInt(10000);
     public static readonly TICKS_PER_MILLISECOND_NUM = 10000;
 

--- a/test-unit/ogg/oggPageHeaderTests.ts
+++ b/test-unit/ogg/oggPageHeaderTests.ts
@@ -61,7 +61,7 @@ import {Testers} from "../utilities/testers";
             OggPageHeader.HEADER_IDENTIFIER,
             0x05, // Version
             0x07, // Flags,
-            ByteVector.fromUlong(0x123456, false), // Absolute granular position
+            0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, // Absolute granular position
             ByteVector.fromUint(0x1234, false), // Stream serial number
             ByteVector.fromUint(0x2345, false), // Page sequence number
             ByteVector.fromSize(4), // Checksum
@@ -82,7 +82,7 @@ import {Testers} from "../utilities/testers";
             OggPageHeader.HEADER_IDENTIFIER,
             0x05, // Version
             0x07, // Flags,
-            ByteVector.fromUlong(0x123456, false), // Absolute granular position
+            0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, // Absolute granular position
             ByteVector.fromUint(0x1234, false), // Stream serial number
             ByteVector.fromUint(0x2345, false), // Page sequence number
             ByteVector.fromSize(4), // Checksum
@@ -98,7 +98,7 @@ import {Testers} from "../utilities/testers";
 
         // Assert
         assert.ok(header);
-        assert.strictEqual(header.absoluteGranularPosition, 0x123456);
+        Testers.bvEqual(header.absoluteGranularPosition, [0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00]);
         assert.strictEqual(header.dataSize, 325);
         assert.strictEqual(header.flags, 0x07);
         assert.isTrue(header.lastPacketComplete);
@@ -116,7 +116,7 @@ import {Testers} from "../utilities/testers";
             OggPageHeader.HEADER_IDENTIFIER,
             0x05, // Version
             0x07, // Flags,
-            ByteVector.fromUlong(0x123456, false), // Absolute granular position
+            0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, // Absolute granular position
             ByteVector.fromUint(0x1234, false), // Stream serial number
             ByteVector.fromUint(0x2345, false), // Page sequence number
             ByteVector.fromSize(4), // Checksum
@@ -132,7 +132,7 @@ import {Testers} from "../utilities/testers";
 
         // Assert
         assert.ok(header);
-        assert.strictEqual(header.absoluteGranularPosition, 0x123456);
+        Testers.bvEqual(header.absoluteGranularPosition, [0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00]);
         assert.strictEqual(header.dataSize, 528);
         assert.strictEqual(header.flags, 0x07);
         assert.isFalse(header.lastPacketComplete);
@@ -164,7 +164,7 @@ import {Testers} from "../utilities/testers";
 
         // Assert
         assert.ok(header);
-        assert.strictEqual(header.absoluteGranularPosition, -1);
+        Testers.bvEqual(header.absoluteGranularPosition, [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]);
         assert.strictEqual(header.dataSize, 255);
         assert.strictEqual(header.flags, 0x07);
         assert.isFalse(header.lastPacketComplete);
@@ -192,7 +192,7 @@ import {Testers} from "../utilities/testers";
 
         // Assert
         assert.ok(header);
-        assert.strictEqual(header.absoluteGranularPosition, 0);
+        Testers.bvEqual(header.absoluteGranularPosition, [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
         assert.strictEqual(header.dataSize, 0);
         assert.strictEqual(header.flags, OggPageFlags.None);
         assert.isFalse(header.lastPacketComplete);
@@ -209,7 +209,7 @@ import {Testers} from "../utilities/testers";
 
         // Assert
         assert.ok(header);
-        assert.strictEqual(header.absoluteGranularPosition, 0);
+        Testers.bvEqual(header.absoluteGranularPosition, [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
         assert.strictEqual(header.dataSize, 0);
         assert.strictEqual(header.flags, OggPageFlags.FirstPageOfStream);
         assert.isFalse(header.lastPacketComplete);
@@ -226,7 +226,7 @@ import {Testers} from "../utilities/testers";
 
         // Assert
         assert.ok(header);
-        assert.strictEqual(header.absoluteGranularPosition, 0);
+        Testers.bvEqual(header.absoluteGranularPosition, [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
         assert.strictEqual(header.dataSize, 0);
         assert.strictEqual(header.flags, OggPageFlags.FirstPacketContinued);
         assert.isFalse(header.lastPacketComplete);
@@ -254,7 +254,7 @@ import {Testers} from "../utilities/testers";
             OggPageHeader.HEADER_IDENTIFIER,
             0x05, // Version
             0x07, // Flags,
-            ByteVector.fromUlong(0x123456, false), // Absolute granular position
+            0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, // Absolute granular position
             ByteVector.fromUint(0x1234, false), // Stream serial number
             ByteVector.fromUint(0x2345, false), // Page sequence number
             ByteVector.fromSize(4), // Checksum
@@ -271,7 +271,7 @@ import {Testers} from "../utilities/testers";
 
         // Assert
         assert.ok(header);
-        assert.strictEqual(header.absoluteGranularPosition, 0x123456);
+        Testers.bvEqual(header.absoluteGranularPosition, [0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00]);
         assert.strictEqual(header.dataSize, 528);
         assert.strictEqual(header.flags, OggPageFlags.None);
         assert.isFalse(header.lastPacketComplete);
@@ -289,7 +289,7 @@ import {Testers} from "../utilities/testers";
             OggPageHeader.HEADER_IDENTIFIER,
             0x05, // Version
             0x07, // Flags,
-            ByteVector.fromUlong(0x123456, false), // Absolute granular position
+            0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, // Absolute granular position
             ByteVector.fromUint(0x1234, false), // Stream serial number
             ByteVector.fromUint(0x00, false), // Page sequence number
             ByteVector.fromSize(4), // Checksum
@@ -306,7 +306,7 @@ import {Testers} from "../utilities/testers";
 
         // Assert
         assert.ok(header);
-        assert.strictEqual(header.absoluteGranularPosition, 0x123456);
+        Testers.bvEqual(header.absoluteGranularPosition, [0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00]);
         assert.strictEqual(header.dataSize, 528);
         assert.strictEqual(header.flags, OggPageFlags.FirstPageOfStream);
         assert.isFalse(header.lastPacketComplete);
@@ -324,7 +324,7 @@ import {Testers} from "../utilities/testers";
             OggPageHeader.HEADER_IDENTIFIER,
             0x05, // Version
             0x07, // Flags,
-            ByteVector.fromUlong(0x123456, false), // Absolute granular position
+            0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, // Absolute granular position
             ByteVector.fromUint(0x1234, false), // Stream serial number
             ByteVector.fromUint(0x00, false), // Page sequence number
             ByteVector.fromSize(4), // Checksum
@@ -341,7 +341,7 @@ import {Testers} from "../utilities/testers";
 
         // Assert
         assert.ok(header);
-        assert.strictEqual(header.absoluteGranularPosition, 0x123456);
+        Testers.bvEqual(header.absoluteGranularPosition, [0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00]);
         assert.strictEqual(header.dataSize, 528);
         assert.strictEqual(header.flags, OggPageFlags.FirstPacketContinued);
         assert.isFalse(header.lastPacketComplete);

--- a/test-unit/ogg/opusCodecTests.ts
+++ b/test-unit/ogg/opusCodecTests.ts
@@ -268,8 +268,8 @@ import {Testers} from "../utilities/testers";
         const codec = Ogg_OpusTests.getTestCodec();
 
         // Act / Assert
-        Testers.testSafeUint((v) => codec.setDuration(v, 123));
-        Testers.testSafeUint((v) => codec.setDuration(123, v));
+        Testers.testTruthy((v: ByteVector) => codec.setDuration(v, ByteVector.fromUlong(123)));
+        Testers.testTruthy((v: ByteVector) => codec.setDuration(ByteVector.fromUlong(123), v));
 
         assert.strictEqual(codec.durationMilliseconds, 0);
     }
@@ -278,9 +278,11 @@ import {Testers} from "../utilities/testers";
     public setDuration_validParameters() {
         // Arrange
         const codec = Ogg_OpusTests.getTestCodec();
+        const first = ByteVector.fromUlong(0, false);
+        const last = ByteVector.fromUlong(123456789, false);
 
         // Act
-        codec.setDuration(0, 123456789);
+        codec.setDuration(first, last);
 
         // Assert
         assert.approximately(codec.durationMilliseconds, 2571995, 0.5);

--- a/test-unit/ogg/theoraCodecTests.ts
+++ b/test-unit/ogg/theoraCodecTests.ts
@@ -228,7 +228,7 @@ import CodecPackets from "./codecPackets";
         codec.setDuration(first, last);
 
         // Assert
-        assert.approximately(codec.durationMilliseconds, 158361612, 1);
+        assert.approximately(codec.durationMilliseconds, 158361612, 10);
     }
 
     private static getTestCodec(): Theora {

--- a/test-unit/ogg/theoraCodecTests.ts
+++ b/test-unit/ogg/theoraCodecTests.ts
@@ -211,8 +211,8 @@ import CodecPackets from "./codecPackets";
         const codec = Ogg_TheoraTests.getTestCodec();
 
         // Act / Assert
-        Testers.testSafeUint((v) => codec.setDuration(v, 123));
-        Testers.testSafeUint((v) => codec.setDuration(123, v));
+        Testers.testTruthy((v: ByteVector) => codec.setDuration(v, ByteVector.empty()));
+        Testers.testTruthy((v: ByteVector) => codec.setDuration(ByteVector.empty(), v));
 
         assert.strictEqual(codec.durationMilliseconds, 0);
     }
@@ -221,9 +221,11 @@ import CodecPackets from "./codecPackets";
     public setDuration_validParameters() {
         // Arrange
         const codec = Ogg_TheoraTests.getTestCodec();
+        const first = ByteVector.fromUlong(123456, false);
+        const last = ByteVector.fromUlong(456789, false);
 
         // Act
-        codec.setDuration(123456, 456789);
+        codec.setDuration(first, last);
 
         // Assert
         assert.approximately(codec.durationMilliseconds, 158361612, 1);

--- a/test-unit/ogg/vorbisCodecTests.ts
+++ b/test-unit/ogg/vorbisCodecTests.ts
@@ -213,8 +213,8 @@ import {Testers} from "../utilities/testers";
         const codec = Ogg_VorbisTests.getTestCodec();
 
         // Act / Assert
-        Testers.testSafeUint((v) => codec.setDuration(v, 123));
-        Testers.testSafeUint((v) => codec.setDuration(123, v));
+        Testers.testTruthy((v: ByteVector) => codec.setDuration(v, ByteVector.empty()));
+        Testers.testTruthy((v: ByteVector) => codec.setDuration(ByteVector.empty(), v));
 
         assert.strictEqual(codec.durationMilliseconds, 0);
     }
@@ -223,9 +223,11 @@ import {Testers} from "../utilities/testers";
     public setDuration_validParameters() {
         // Arrange
         const codec = Ogg_VorbisTests.getTestCodec();
+        const first = ByteVector.fromUlong(123456, false);
+        const last = ByteVector.fromUlong(456789, false);
 
         // Act
-        codec.setDuration(123456, 456789);
+        codec.setDuration(first, last);
 
         // Assert
         assert.approximately(codec.durationMilliseconds, 729, 1);


### PR DESCRIPTION
According to OGG spec, the page header's granule position must be monotonically increasing, but doesn't specify if the value is a number or anything. As such, we shouldn't store it as a number and should just represent it as a byte vector. Is this strictly necessary ... well no not really, especially since it increases some complexities by needing to screw around with bigints. But, even if we treated it as a number, it would need to be a bigint anyways. So ... whatever.