### PR TITLE
Non-standard ID3v2 frame identifier support

### DIFF
--- a/src/id3v2/frames/frameHeader.ts
+++ b/src/id3v2/frames/frameHeader.ts
@@ -97,7 +97,8 @@ export class Id3v2FrameHeader {
             throw new Error("Data must contain at least a frame ID");
         }
 
-        let frameId;
+        let rawFrameId: string;
+        let frameId: FrameIdentifier;
         let flags = 0;
         let frameSize = 0;
         switch (version) {
@@ -107,7 +108,8 @@ export class Id3v2FrameHeader {
                 }
 
                 // Set frame ID -- first 3 bytes
-                frameId = FrameIdentifiers[data.subarray(0, 3).toString(StringType.Latin1)];
+                rawFrameId = data.subarray(0, 3).toString(StringType.Latin1);
+                frameId = FrameIdentifiers[rawFrameId] || new FrameIdentifier(undefined, undefined, rawFrameId);
 
                 // If the full header information was not passed in, do not continue to the steps
                 // to parse the frame size and flags.
@@ -124,7 +126,8 @@ export class Id3v2FrameHeader {
                 }
 
                 // Set the frame ID -- first 4 bytes
-                frameId = FrameIdentifiers[data.subarray(0, 4).toString(StringType.Latin1)];
+                rawFrameId = data.subarray(0, 4).toString(StringType.Latin1);
+                frameId = FrameIdentifiers[rawFrameId] || new FrameIdentifier(undefined, rawFrameId, undefined);
 
                 // If the full header information was not passed in, do not continue to the steps
                 // to parse the frame size and flags.
@@ -147,12 +150,13 @@ export class Id3v2FrameHeader {
                 }
 
                 // Set the frame ID -- the first 4 bytes
-                frameId = FrameIdentifiers[data.subarray(0, 4).toString(StringType.Latin1)];
+                rawFrameId = data.subarray(0, 4).toString(StringType.Latin1);
+                frameId = FrameIdentifiers[rawFrameId] || new FrameIdentifier(rawFrameId, undefined, undefined);
 
                 // If the full header information was not passed in, do not continue to the steps to
                 // ... eh, you probably get it by now.
                 if (data.length < 10) {
-                    return;
+                    break;
                 }
 
                 frameSize = SyncData.toUint(data.subarray(4, 4));

--- a/test-unit/id3v2/frameHeaderTests.ts
+++ b/test-unit/id3v2/frameHeaderTests.ts
@@ -1,0 +1,138 @@
+import {suite, test} from "@testdeck/mocha";
+import {assert} from "chai";
+
+import {ByteVector, StringType} from "../../src/byteVector";
+import {Id3v2FrameHeader} from "../../src/id3v2/frames/frameHeader";
+import {Testers} from "../utilities/testers";
+import {FrameIdentifiers} from "../../src/id3v2/frameIdentifiers";
+
+@suite class FrameHeaderTests {
+    @test
+    public fromData_invalid() {
+        // Arrange
+        const testBytes = ByteVector.empty();
+
+        // Act / Assert
+        Testers.testTruthy((v: ByteVector) => Id3v2FrameHeader.fromData(v, 3));
+        Testers.testUint((v) => Id3v2FrameHeader.fromData(testBytes, v));
+        assert.throws(() => Id3v2FrameHeader.fromData(testBytes, 1));
+        assert.throws(() => Id3v2FrameHeader.fromData(testBytes, 5));
+    }
+
+    @test
+    public fromData_v2_tooShort() {
+        // Arrange
+        const testBytes = ByteVector.fromSize(2);
+
+        // Act / Assert
+        assert.throws(() => Id3v2FrameHeader.fromData(testBytes, 2));
+    }
+
+    @test
+    public fromData_v2_standardIdentifier() {
+        // Arrange
+        const testBytes = ByteVector.fromString("TT1", StringType.Latin1);
+
+        // Act
+        const header = Id3v2FrameHeader.fromData(testBytes, 2);
+
+        // Assert
+        assert.isOk(header);
+        assert.strictEqual(header.frameId, FrameIdentifiers['TIT1']);
+        assert.strictEqual(header.flags, 0);
+        assert.strictEqual(header.frameSize, 0);
+    }
+
+    @test
+    public fromData_v2_nonstandardIdentifier() {
+        // Arrange
+        const testBytes = ByteVector.fromString("NON", StringType.Latin1);
+
+        // Act
+        const header = Id3v2FrameHeader.fromData(testBytes, 2);
+
+        // Assert
+        assert.isOk(header);
+        Testers.bvEqual(header.frameId.render(2), testBytes);
+        assert.strictEqual(header.flags, 0);
+        assert.strictEqual(header.frameSize, 0);
+    }
+
+    @test
+    public fromData_v3_tooShort() {
+        // Arrange
+        const testBytes = ByteVector.fromSize(3);
+
+        // Act / Assert
+        assert.throws(() => Id3v2FrameHeader.fromData(testBytes, 3));
+    }
+
+    @test
+    public fromData_v3_standardIdentifier() {
+        // Arrange
+        const testBytes = ByteVector.fromString("TIT1", StringType.Latin1);
+
+        // Act
+        const header = Id3v2FrameHeader.fromData(testBytes, 3);
+
+        // Assert
+        assert.isOk(header);
+        assert.strictEqual(header.frameId, FrameIdentifiers['TIT1']);
+        assert.strictEqual(header.flags, 0);
+        assert.strictEqual(header.frameSize, 0);
+    }
+
+    @test
+    public fromData_v3_nonstandardIdentifier() {
+        // Arrange
+        const testBytes = ByteVector.fromString("NON1", StringType.Latin1);
+
+        // Act
+        const header = Id3v2FrameHeader.fromData(testBytes, 3);
+
+        // Assert
+        assert.isOk(header);
+        Testers.bvEqual(header.frameId.render(3), testBytes);
+        assert.strictEqual(header.flags, 0);
+        assert.strictEqual(header.frameSize, 0);
+    }
+
+    @test
+    public fromData_v4_tooShort() {
+        // Arrange
+        const testBytes = ByteVector.fromSize(3);
+
+        // Act / Assert
+        assert.throws(() => Id3v2FrameHeader.fromData(testBytes, 4));
+    }
+
+    @test
+    public fromData_v4_standardIdentifier() {
+        // Arrange
+        const testBytes = ByteVector.fromString("TIT1", StringType.Latin1);
+
+        // Act
+        const header = Id3v2FrameHeader.fromData(testBytes, 4);
+
+        // Assert
+        assert.isOk(header);
+        assert.strictEqual(header.frameId, FrameIdentifiers['TIT1']);
+        assert.strictEqual(header.flags, 0);
+        assert.strictEqual(header.frameSize, 0);
+    }
+
+    @test
+    public fromData_v4_nonstandardIdentifier() {
+        // Arrange
+        const testBytes = ByteVector.fromString("NON1", StringType.Latin1);
+
+        // Act
+        const header = Id3v2FrameHeader.fromData(testBytes, 4);
+
+        // Assert
+        assert.isOk(header);
+        Testers.bvEqual(header.frameId.render(4), testBytes);
+        assert.strictEqual(header.flags, 0);
+        assert.strictEqual(header.frameSize, 0);
+    }
+}


### PR DESCRIPTION
**Description**: Changes processing for ID3v2 frames such that if a frame identifier is non-standard, a new instance of `FrameIdentifier` is created allowing the frame factory to treat the frame as an `UnknownFrame`.

**Testing**:
* Existing tests continue to pass
* New tests added for verifying the behavior of non-standard frame identifiers