### PR TITLE
Fixing GEOB Latin1 Encoding Bug

### DIFF
--- a/src/id3v2/frames/attachmentFrame.ts
+++ b/src/id3v2/frames/attachmentFrame.ts
@@ -429,7 +429,7 @@ export default class AttachmentFrame extends Frame implements IPicture {
             // Filename               <text string according to encoding> $00 (00)
             // Content description    <text string according to encoding> $00 (00)
             // Encapsulated object    <binary data>
-            const mimeTypeEndIndex = data.find(ByteVector.getTextDelimiter(StringType.Latin1));
+            const mimeTypeEndIndex = data.offsetFind(ByteVector.getTextDelimiter(StringType.Latin1), 1);
             if (mimeTypeEndIndex === -1) {
                 return;
             }

--- a/test-unit/id3v2/attachmentsFrameTests.ts
+++ b/test-unit/id3v2/attachmentsFrameTests.ts
@@ -240,7 +240,7 @@ const getCustomTestFrame = (
     }
 
     @test
-    public fromRawData_geob() {
+    public fromRawData_geob_nonLatinEncoding() {
         // Arrange
         const testData = ByteVector.fromString("fuxbuxqux", StringType.Latin1);
         const header = new Id3v2FrameHeader(FrameIdentifiers.GEOB);
@@ -269,6 +269,40 @@ const getCustomTestFrame = (
             "image.gif",
             "image/gif",
             StringType.UTF16BE,
+            PictureType.NotAPicture
+        );
+    }
+
+    @test
+    public fromRawData_geob_latinEncoding() {
+        // Arrange
+        const testData = ByteVector.fromString("fuxbuxqux", StringType.Latin1);
+        const header = new Id3v2FrameHeader(FrameIdentifiers.GEOB);
+        header.frameSize = 60;
+        const data = ByteVector.concatenate(
+            header.render(4),
+            StringType.Latin1,
+            ByteVector.fromString("image/gif", StringType.Latin1),
+            ByteVector.getTextDelimiter(StringType.Latin1),
+            ByteVector.fromString("image.gif", StringType.Latin1),
+            ByteVector.getTextDelimiter(StringType.Latin1),
+            ByteVector.fromString("foobarbaz", StringType.Latin1),
+            ByteVector.getTextDelimiter(StringType.Latin1),
+            testData
+        );
+
+        // Act
+        const frame = AttachmentFrame.fromRawData(data, 4);
+
+        // Assert
+        Id3v2_AttachmentFrame_ConstructorTests.verifyFrame(
+            frame,
+            FrameIdentifiers.GEOB,
+            testData,
+            "foobarbaz",
+            "image.gif",
+            "image/gif",
+            StringType.Latin1,
             PictureType.NotAPicture
         );
     }


### PR DESCRIPTION
**Description**: Fixing a bug likely introduced when doing the bytevector refactoring. Discovered when trying to mess around with one of my files that contained an (unknown to me) GEOB frame. The GEOB frame contained a cue points table, likely stored by rekordcloud. The frame was encoded in Latin1 encoding, which means the GEOB frame starts with `0x00`. The attachment frame parser starts by looking for `0x00` to determine the end of the mime type. If the frame is encoded in Latin1, the parser will think the mime type is 0 bytes long, leading to a failure. The fix is to introduce an offset in searching for mime type delimiter.

**Testing**:
* Added a test to verify the behavior of GEOB when encoded with Latin1