### PR TITLE
Fix-duration

### DIFF
--- a/src/mpeg/mpegAudioHeader.ts
+++ b/src/mpeg/mpegAudioHeader.ts
@@ -90,7 +90,7 @@ export default class MpegAudioHeader implements IAudioCodec {
         file.seek(position + XingHeader.xingHeaderOffset(header.version, header.channelMode));
 
         const xingData = file.readBlock(16);
-        if (xingData.length === 16 && xingData.startsWith(XingHeader.FILE_IDENTIFIER)) {
+        if (xingData.length === 16 && (xingData.startsWith(XingHeader.FILE_IDENTIFIER) || xingData.startsWith(XingHeader.FILE_IDENTIFIER_INFO))) {
             header._xingHeader = XingHeader.fromData(xingData);
         }
 

--- a/src/mpeg/xingHeader.ts
+++ b/src/mpeg/xingHeader.ts
@@ -49,8 +49,10 @@ export default class XingHeader {
     public static fromData(data: ByteVector): XingHeader {
         Guards.truthy(data, "data");
 
+        const isInfoHeader = data.startsWith(XingHeader.FILE_IDENTIFIER_INFO);
+
         // Check to see if a valid Xing header is available
-        if (!data.startsWith(XingHeader.FILE_IDENTIFIER) && !data.startsWith(XingHeader.FILE_IDENTIFIER_INFO)) {
+        if (!data.startsWith(XingHeader.FILE_IDENTIFIER) && !isInfoHeader) {
             throw new CorruptFileError("Not a valid Xing header");
         }
 
@@ -70,7 +72,7 @@ export default class XingHeader {
             header._totalSize = 0;
         }
 
-        header._isPresent = true;
+        header._isPresent = !isInfoHeader;
 
         return header;
     }

--- a/src/mpeg/xingHeader.ts
+++ b/src/mpeg/xingHeader.ts
@@ -11,6 +11,7 @@ export default class XingHeader {
      * Identifier that appears in a file to indicate the start of a Xing header.
      */
     public static readonly FILE_IDENTIFIER = ByteVector.fromString("Xing", StringType.Latin1).makeReadOnly();
+    public static readonly FILE_IDENTIFIER_INFO = ByteVector.fromString("Info", StringType.Latin1).makeReadOnly();
 
     /**
      * An empty an unset Xing header
@@ -49,7 +50,7 @@ export default class XingHeader {
         Guards.truthy(data, "data");
 
         // Check to see if a valid Xing header is available
-        if (!data.startsWith(XingHeader.FILE_IDENTIFIER)) {
+        if (!data.startsWith(XingHeader.FILE_IDENTIFIER) && !data.startsWith(XingHeader.FILE_IDENTIFIER_INFO)) {
             throw new CorruptFileError("Not a valid Xing header");
         }
 

--- a/src/riff/riffFile.ts
+++ b/src/riff/riffFile.ts
@@ -374,9 +374,9 @@ export default class RiffFile extends File {
                 }
 
                 codecs = [waveHeader];
-                // durationMilliseconds = dataChunk.originalDataSize * 8000
-                //     / waveHeader.bitsPerSample / waveHeader.audioSampleRate;
-                durationMilliseconds = dataChunk.originalDataSize * 1000 / waveHeader.averageBytesPerSecond
+                durationMilliseconds = waveHeader.averageBytesPerSecond
+                    ? dataChunk.originalDataSize * 1000 / waveHeader.averageBytesPerSecond
+                    : dataChunk.originalDataSize * 8000 / waveHeader.bitsPerSample / waveHeader.audioSampleRate;
                 break;
 
             case "AVI ":

--- a/src/riff/riffFile.ts
+++ b/src/riff/riffFile.ts
@@ -374,8 +374,9 @@ export default class RiffFile extends File {
                 }
 
                 codecs = [waveHeader];
-                durationMilliseconds = dataChunk.originalDataSize * 8000
-                    / waveHeader.bitsPerSample / waveHeader.audioSampleRate;
+                // durationMilliseconds = dataChunk.originalDataSize * 8000
+                //     / waveHeader.bitsPerSample / waveHeader.audioSampleRate;
+                durationMilliseconds = dataChunk.originalDataSize * 1000 / waveHeader.averageBytesPerSecond
                 break;
 
             case "AVI ":

--- a/test-unit/riff/riffFileTests.ts
+++ b/test-unit/riff/riffFileTests.ts
@@ -359,7 +359,7 @@ import {Testers} from "../utilities/testers";
             assert.strictEqual(file.properties.codecs.length, 1);
             assert.isOk(file.properties.codecs.find((c) => c instanceof RiffWaveFormatEx));
             assert.isNotOk(file.properties.codecs.find((c) => c instanceof RiffBitmapInfoHeader));
-            assert.approximately(file.properties.durationMilliseconds, 405, 1);
+            assert.approximately(file.properties.durationMilliseconds, 426, 1);
 
             assert.isOk(file.tag);
             assert.instanceOf(file.tag, RiffTags);
@@ -399,7 +399,7 @@ import {Testers} from "../utilities/testers";
             assert.strictEqual(file.properties.codecs.length, 1);
             assert.isOk(file.properties.codecs.find((c) => c instanceof RiffWaveFormatEx));
             assert.isNotOk(file.properties.codecs.find((c) => c instanceof RiffBitmapInfoHeader));
-            assert.approximately(file.properties.durationMilliseconds, 405, 1);
+            assert.approximately(file.properties.durationMilliseconds, 426, 1);
 
             assert.isOk(file.tag);
             assert.instanceOf(file.tag, RiffTags);
@@ -507,7 +507,7 @@ import {Testers} from "../utilities/testers";
         assert.isOk(file.properties.codecs);
         assert.strictEqual(file.properties.codecs.length, 1);
         assert.isOk(file.properties.codecs.find((c) => c instanceof RiffWaveFormatEx));
-        assert.approximately(file.properties.durationMilliseconds, 405, 1);
+        assert.approximately(file.properties.durationMilliseconds, 426, 1);
 
         assert.isOk(file.tag);
         assert.instanceOf(file.tag, RiffTags);


### PR DESCRIPTION
see #95

### MPEG

For MPEG file, it appears that `Info` is also a valid token for `XingHeader` (see in [c++](https://github.com/taglib/taglib/blob/51d63ab2858818be7707c884a284f3fe6210085d/taglib/mpeg/xingheader.cpp#L83-L85) implemention).

### RIFF

For WAVE file, it appears that the duration can be correctly calculated using the `averageBytesPerSecond` (see in [C#](https://github.com/mono/taglib-sharp/blob/c853d26fcf831b9c7bf1b1bc7734c2a8690ca163/src/TaglibSharp/Riff/File.cs#L498) implemention), which resolves the incorrect duration issue.

However, this also causes the test to fail, indicating that further improvements may be necessary.