### PR TITLE
Remove `.fromRawData()` static constructors from ID3v2 frames

### DIFF
--- a/src/id3v2/frames/attachmentFrame.ts
+++ b/src/id3v2/frames/attachmentFrame.ts
@@ -101,21 +101,6 @@ export default class AttachmentFrame extends Frame implements IPicture {
         return frame;
     }
 
-    /**
-     * Constructs and initializes a new attachment frame by reading its raw data in a specified
-     * Id3v2 version.
-     * @param data ByteVector starting with the raw representation of the new frame
-     * @param version ID3v2 version the raw frame is encoded with.
-     */
-    public static fromRawData(data: ByteVector, version: number): AttachmentFrame {
-        Guards.truthy(data, "data");
-        Guards.byte(version, "version");
-
-        const frame = new AttachmentFrame(Id3v2FrameHeader.fromData(data, version));
-        frame.setData(data, 0, true, version);
-        return frame;
-    }
-
     // #endregion
 
     // #region Properties

--- a/src/id3v2/frames/commentsFrame.ts
+++ b/src/id3v2/frames/commentsFrame.ts
@@ -70,22 +70,6 @@ export default class CommentsFrame extends Frame {
         return frame;
     }
 
-    /**
-     * Constructs and initializes a new CommentsFrame by reading its raw data in a specified
-     * ID3v2 version.
-     * @param data Raw representation of the new frame
-     * @param version ID3v2 version the raw frame is encoded with, must be a positive 8-bit integer
-     * @param version ID3v2 version the frame was originally encoded with
-     */
-    public static fromRawData(data: ByteVector, version: number): CommentsFrame {
-        Guards.truthy(data, "data");
-        Guards.byte(version, "version");
-
-        const frame = new CommentsFrame(Id3v2FrameHeader.fromData(data, version));
-        frame.setData(data, 0, true, version);
-        return frame;
-    }
-
     // #endregion
 
     // #region Public Properties

--- a/src/id3v2/frames/eventTimeCodeFrame.ts
+++ b/src/id3v2/frames/eventTimeCodeFrame.ts
@@ -133,21 +133,6 @@ export class EventTimeCodeFrame extends Frame {
         return frame;
     }
 
-    /**
-     * Constructs and initializes a new instance by reading its raw data in a specified
-     * ID3v2 version.
-     * @param data Raw representation of the new frame
-     * @param version ID3v2 version the raw frame is encoded with, must be a positive 8-bit integer
-     */
-    public static fromRawData(data: ByteVector, version: number): EventTimeCodeFrame {
-        Guards.truthy(data, "data");
-        Guards.byte(version, "version");
-
-        const frame = new EventTimeCodeFrame(Id3v2FrameHeader.fromData(data, version));
-        frame.setData(data, 0, true, version);
-        return frame;
-    }
-
     // #endregion
 
     // #region Properties

--- a/src/id3v2/frames/frame.ts
+++ b/src/id3v2/frames/frame.ts
@@ -338,6 +338,7 @@ export abstract class Frame {
         version: number,
         dataIncludesHeader: boolean
     ): ByteVector {
+        // @TODO: Subarrays are cheap now, we could do this all without an offset.
         let dataOffset = offset + (dataIncludesHeader ? Id3v2FrameHeader.getSize(version) : 0);
         let dataLength = this.size;
 
@@ -410,6 +411,8 @@ export abstract class Frame {
         if (readHeader) {
             this._header = Id3v2FrameHeader.fromData(data, version);
         }
+
+        // @TODO: If we don't have a header to read, why are we saying the data includes a header?
         this.parseFields(this.fieldData(data, offset, version, true), version);
     }
 

--- a/src/id3v2/frames/musicCdIdentifierFrame.ts
+++ b/src/id3v2/frames/musicCdIdentifierFrame.ts
@@ -40,21 +40,6 @@ export default class MusicCdIdentifierFrame extends Frame {
         return frame;
     }
 
-    /**
-     * Constructs and initializes a new instance of MusicCdIdentifierFrame by reading its raw data
-     * in a specified ID3v2 version.
-     * @param data ByteVector object starting with the raw representation of the new frame
-     * @param version The ID3v2 version the raw frame is encoded in. Must be positive 8-bit integer
-     */
-    public static fromRawData(data: ByteVector, version: number): MusicCdIdentifierFrame {
-        Guards.truthy(data, "data");
-        Guards.byte(version, "version");
-
-        const frame = new MusicCdIdentifierFrame(Id3v2FrameHeader.fromData(data, version));
-        frame.setData(data, 0, true, version);
-        return frame;
-    }
-
     /** @inheritDoc */
     public get frameClassType(): FrameClassType { return FrameClassType.MusicCdIdentifierFrame; }
 

--- a/src/id3v2/frames/playCountFrame.ts
+++ b/src/id3v2/frames/playCountFrame.ts
@@ -49,21 +49,6 @@ export default class PlayCountFrame extends Frame {
         return frame;
     }
 
-    /**
-     * Constructs and initializes a new instance by reading its raw data in a specified ID3v2
-     * version
-     * @param data ByteVector starting with the raw representation of the new frame
-     * @param version ID3v2 version the raw frame is encoded in, must be a positive 8-bit integer
-     */
-    public static fromRawData(data: ByteVector, version: number): PlayCountFrame {
-        Guards.truthy(data, "data");
-        Guards.byte(version, "version");
-
-        const frame = new PlayCountFrame(Id3v2FrameHeader.fromData(data, version));
-        frame.setData(data, 0, true, version);
-        return frame;
-    }
-
     // #endregion
 
     // #region Public Properties

--- a/src/id3v2/frames/popularimeterFrame.ts
+++ b/src/id3v2/frames/popularimeterFrame.ts
@@ -45,21 +45,6 @@ export default class PopularimeterFrame extends Frame {
     }
 
     /**
-     * Constructs and initializes a new instance by reading its raw data in a specified
-     * ID3v2 version.
-     * @param data Raw representation of the new frame
-     * @param version ID3v2 version the raw frame is encoded with, must be a positive 8-bit integer
-     */
-    public static fromRawData(data: ByteVector, version: number): PopularimeterFrame {
-        Guards.truthy(data, "data");
-        Guards.byte(version, "version");
-
-        const frame = new PopularimeterFrame(Id3v2FrameHeader.fromData(data, version));
-        frame.setData(data, 0, true, version);
-        return frame;
-    }
-
-    /**
      * Constructs and initializes a new instance for a specified user with a rating and play count
      * of zero.
      * @param user Email of the user that gave the rating

--- a/src/id3v2/frames/privateFrame.ts
+++ b/src/id3v2/frames/privateFrame.ts
@@ -56,21 +56,6 @@ export default class PrivateFrame extends Frame {
         return frame;
     }
 
-    /**
-     * Constructs and initializes a new instance by reading its raw data in a specified
-     * ID3v2 version.
-     * @param data Raw representation of the new frame
-     * @param version ID3v2 version the raw frame is encoded with, must be a positive 8-bit integer
-     */
-    public static fromRawData(data: ByteVector, version: number): PrivateFrame {
-        Guards.truthy(data, "data");
-        Guards.byte(version, "version");
-
-        const frame = new PrivateFrame(Id3v2FrameHeader.fromData(data, version));
-        frame.setData(data, 0, true, version);
-        return frame;
-    }
-
     // #endregion
 
     // #region Public Properties

--- a/src/id3v2/frames/relativeVolumeFrame.ts
+++ b/src/id3v2/frames/relativeVolumeFrame.ts
@@ -229,21 +229,6 @@ export class RelativeVolumeFrame extends Frame {
         return frame;
     }
 
-    /**
-     * Constructs and initializes a new instance by reading its raw data in a specified ID3v2
-     * version.
-     * @param data Raw representation of the new frame
-     * @param version ID3v2 version the frame is encoded with. Must be a positive 8-bit integer.
-     */
-    public static fromRawData(data: ByteVector, version: number): RelativeVolumeFrame {
-        Guards.truthy(data, "data");
-        Guards.byte(version, "version");
-
-        const frame = new RelativeVolumeFrame(Id3v2FrameHeader.fromData(data, version));
-        frame.setData(data, 0, true, version);
-        return frame;
-    }
-
     // #endregion
 
     // #region Properties

--- a/src/id3v2/frames/synchronizedLyricsFrame.ts
+++ b/src/id3v2/frames/synchronizedLyricsFrame.ts
@@ -132,21 +132,6 @@ export class SynchronizedLyricsFrame extends Frame {
         return frame;
     }
 
-    /**
-     * Constructs and initializes a new instance by reading its raw data in a specified ID3v2
-     * format.
-     * @param data Raw representation of the new instance
-     * @param version ID3v2 version the raw frame is encoded with. Must be unsigned 8-bit integer.
-     */
-    public static fromRawData(data: ByteVector, version: number): SynchronizedLyricsFrame {
-        Guards.truthy(data, "data");
-        Guards.byte(version, "version");
-
-        const frame = new SynchronizedLyricsFrame(Id3v2FrameHeader.fromData(data, version));
-        frame.setData(data, 0, true, version);
-        return frame;
-    }
-
     // #endregion
 
     // #region Properties

--- a/src/id3v2/frames/termsOfUseFrame.ts
+++ b/src/id3v2/frames/termsOfUseFrame.ts
@@ -58,21 +58,6 @@ export default class TermsOfUseFrame extends Frame {
         return frame;
     }
 
-    /**
-     * Constructs and initializes a new instance by reading its raw data in a specified
-     * ID3v2 version.
-     * @param data Raw representation of the new frame
-     * @param version ID3v2 version the raw frame is encoded with, must be a positive 8-bit integer
-     */
-    public static fromRawData(data: ByteVector, version: number): TermsOfUseFrame {
-        Guards.truthy(data, "data");
-        Guards.byte(version, "version");
-
-        const frame = new TermsOfUseFrame(Id3v2FrameHeader.fromData(data, version));
-        frame.setData(data, 0, true, version);
-        return frame;
-    }
-
     // #endregion
 
     // #region Properties

--- a/src/id3v2/frames/textInformationFrame.ts
+++ b/src/id3v2/frames/textInformationFrame.ts
@@ -687,21 +687,6 @@ export class UserTextInformationFrame extends TextInformationFrame {
         return frame;
     }
 
-    /**
-     * Constructs and initializes a new instance by reading its raw data in a specified
-     * ID3v2 version.
-     * @param data Raw representation of the new frame
-     * @param version ID3v2 version the raw frame is encoded with, must be a positive 8-bit integer
-     */
-    public static fromRawData(data: ByteVector, version: number): UserTextInformationFrame {
-        Guards.truthy(data, "data");
-        Guards.byte(version, "version");
-
-        const frame = new UserTextInformationFrame(Id3v2FrameHeader.fromData(data, version));
-        frame.setData(data, 0, true, version);
-        return frame;
-    }
-
     // #endregion
 
     // #region Properties

--- a/src/id3v2/frames/textInformationFrame.ts
+++ b/src/id3v2/frames/textInformationFrame.ts
@@ -214,21 +214,6 @@ export class TextInformationFrame extends Frame {
         return frame;
     }
 
-    /**
-     * Constructs and initializes a new instance by reading its raw data in a specified
-     * ID3v2 version.
-     * @param data Raw representation of the new frame
-     * @param version ID3v2 version the raw frame is encoded with, must be a positive 8-bit integer
-     */
-    public static fromRawData(data: ByteVector, version: number): TextInformationFrame {
-        Guards.truthy(data, "data");
-        Guards.byte(version, "version");
-
-        const frame = new TextInformationFrame(Id3v2FrameHeader.fromData(data, version));
-        frame.setData(data, 0, true, version);
-        return frame;
-    }
-
     // #endregion
 
     // #region Properties

--- a/src/id3v2/frames/uniqueFileIdentifierFrame.ts
+++ b/src/id3v2/frames/uniqueFileIdentifierFrame.ts
@@ -59,21 +59,6 @@ export default class UniqueFileIdentifierFrame extends Frame {
         return frame;
     }
 
-    /**
-     * Constructs and initializes a new instance by reading its raw data in a specified
-     * ID3v2 version.
-     * @param data Raw representation of the new frame
-     * @param version ID3v2 version the raw frame is encoded with, must be a positive 8-bit integer
-     */
-    public static fromRawData(data: ByteVector, version: number): UniqueFileIdentifierFrame {
-        Guards.truthy(data, "data");
-        Guards.byte(version, "version");
-
-        const frame = new UniqueFileIdentifierFrame(Id3v2FrameHeader.fromData(data, version));
-        frame.setData(data, 0, true, version);
-        return frame;
-    }
-
     // #endregion
 
     // #region Properties

--- a/src/id3v2/frames/unknownFrame.ts
+++ b/src/id3v2/frames/unknownFrame.ts
@@ -50,21 +50,6 @@ export default class UnknownFrame extends Frame {
         return frame;
     }
 
-    /**
-     * Constructs and initializes a new instance by reading its raw data in a specified
-     * ID3v2 version.
-     * @param data Raw representation of the new frame
-     * @param version ID3v2 version the raw frame is encoded with, must be a positive 8-bit integer
-     */
-    public static fromRawData(data: ByteVector, version: number): UnknownFrame {
-        Guards.truthy(data, "data");
-        Guards.byte(version, "version");
-
-        const frame = new UnknownFrame(Id3v2FrameHeader.fromData(data, version));
-        frame.setData(data, 0, true, version);
-        return frame;
-    }
-
     /** @inheritDoc */
     public get frameClassType(): FrameClassType { return FrameClassType.UnknownFrame; }
 

--- a/src/id3v2/frames/unsynchronizedLyricsFrame.ts
+++ b/src/id3v2/frames/unsynchronizedLyricsFrame.ts
@@ -64,21 +64,6 @@ export default class UnsynchronizedLyricsFrame extends Frame {
         return frame;
     }
 
-    /**
-     * Constructs and initializes a new instance by reading its raw data in a specified
-     * ID3v2 version.
-     * @param data Raw representation of the new frame
-     * @param version ID3v2 version the raw frame is encoded with, must be a positive 8-bit integer
-     */
-    public static fromRawData(data: ByteVector, version: number): UnsynchronizedLyricsFrame {
-        Guards.truthy(data, "data");
-        Guards.byte(version, "version");
-
-        const frame = new UnsynchronizedLyricsFrame(Id3v2FrameHeader.fromData(data, version));
-        frame.setData(data, 0, true, version);
-        return frame;
-    }
-
     // #endregion
 
     // #region Properties

--- a/src/id3v2/frames/urlLinkFrame.ts
+++ b/src/id3v2/frames/urlLinkFrame.ts
@@ -94,21 +94,6 @@ export class UrlLinkFrame extends Frame {
         return frame;
     }
 
-    /**
-     * Constructs and initializes a new instance by reading its raw data in a specified
-     * ID3v2 version.
-     * @param data Raw representation of the new frame
-     * @param version ID3v2 version the raw frame is encoded with, must be a positive 8-bit integer
-     */
-    public static fromRawData(data: ByteVector, version: number): UrlLinkFrame {
-        Guards.truthy(data, "data");
-        Guards.byte(version, "version");
-
-        const frame = new UrlLinkFrame(Id3v2FrameHeader.fromData(data, version));
-        frame.setData(data, 0, true, version);
-        return frame;
-    }
-
     // #endregion
 
     // #region Properties

--- a/src/id3v2/frames/urlLinkFrame.ts
+++ b/src/id3v2/frames/urlLinkFrame.ts
@@ -296,21 +296,6 @@ export class UserUrlLinkFrame extends UrlLinkFrame {
         return frame;
     }
 
-    /**
-     * Constructs and initializes a new instance by reading its raw data in a specified
-     * ID3v2 version.
-     * @param data Raw representation of the new frame
-     * @param version ID3v2 version the raw frame is encoded with, must be a positive 8-bit integer
-     */
-    public static fromRawData(data: ByteVector, version: number): UserUrlLinkFrame {
-        Guards.truthy(data, "data");
-        Guards.byte(version, "version");
-
-        const frame = new UserUrlLinkFrame(Id3v2FrameHeader.fromData(data, version));
-        frame.setData(data, 0, true, version);
-        return frame;
-    }
-
     // #endregion
 
     // #region Properties

--- a/test-unit/id3v2/attachmentsFrameTests.ts
+++ b/test-unit/id3v2/attachmentsFrameTests.ts
@@ -42,10 +42,7 @@ const getCustomTestFrame = (
     get fromOffsetRawData(): (d: ByteVector, o: number, h: Id3v2FrameHeader, v: number) => Frame {
         return AttachmentFrame.fromOffsetRawData;
     }
-
-    get fromRawData(): (d: ByteVector, v: number) => Frame {
-        return AttachmentFrame.fromRawData;
-    }
+    get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
 
     @test
     public fromPicture_falsyPicture() {
@@ -107,48 +104,20 @@ const getCustomTestFrame = (
         );
     }
 
-    @test
-    public fromRawData_invalidFrameIdentifier() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.TXXX);
-        header.frameSize = 10;
-        const data = ByteVector.concatenate(
-            header.render(4),
-            ByteVector.fromSize(10)
-        );
-
-        // Act / Assert
-        const frame = AttachmentFrame.fromRawData(data, 4);
-        assert.throws(() => frame.type);
-    }
-
-    @test
-    public fromRawData_dataTooShort() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.APIC);
-        header.frameSize = 3;
-        const data = ByteVector.concatenate(
-            header.render(4),
-            ByteVector.fromSize(3, 0x00)
-        );
-
-        // Act / Assert
-        assert.throws(() => AttachmentFrame.fromRawData(data, 4));
-    }
-
     // NOTE: If you're wondering why we have a test for latin1 vs other encodings, it's b/c the
     //    mimetype detection looks for a 0 to mark the end of the mimetype. If encoding is Latin1,
     //    the first byte of the picture is 0, which we want to make sure isn't mistaken for the end
     //    of the mimetype.
 
     @test
-    public fromRawData_apicV4_latin1Encoding() {
+    public fromOffsetRawData_apicV4_latin1Encoding() {
         // Arrange
         const testData = ByteVector.fromString("fuxbuxqux", StringType.Latin1);
         const header = new Id3v2FrameHeader(FrameIdentifiers.APIC);
         header.frameSize = 41;
         const data = ByteVector.concatenate(
             header.render(4),
+            0x00, 0x00,
             StringType.Latin1,
             ByteVector.fromString("image/gif", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),
@@ -159,7 +128,7 @@ const getCustomTestFrame = (
         );
 
         // Act
-        const frame = AttachmentFrame.fromRawData(data, 4);
+        const frame = AttachmentFrame.fromOffsetRawData(data, 2, header, 4);
 
         // Assert
         Id3v2_AttachmentFrame_ConstructorTests.verifyFrame(
@@ -175,13 +144,14 @@ const getCustomTestFrame = (
     }
 
     @test
-    public fromRawData_apicV4_nonLatinEncoding() {
+    public fromOffsetRawData_apicV4_nonLatinEncoding() {
         // Arrange
         const testData = ByteVector.fromString("fuxbuxqux", StringType.Latin1);
         const header = new Id3v2FrameHeader(FrameIdentifiers.APIC);
         header.frameSize = 41;
         const data = ByteVector.concatenate(
             header.render(4),
+            0x00, 0x00,
             StringType.UTF16BE,
             ByteVector.fromString("image/gif", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),
@@ -192,7 +162,7 @@ const getCustomTestFrame = (
         );
 
         // Act
-        const frame = AttachmentFrame.fromRawData(data, 4);
+        const frame = AttachmentFrame.fromOffsetRawData(data, 2, header, 4);
 
         // Assert
         Id3v2_AttachmentFrame_ConstructorTests.verifyFrame(
@@ -208,13 +178,14 @@ const getCustomTestFrame = (
     }
 
     @test
-    public fromRawData_apicV2() {
+    public fromOffsetRawData_apicV2() {
         // Arrange
         const testData = ByteVector.fromString("fuxbuxqux", StringType.Latin1);
         const header = new Id3v2FrameHeader(FrameIdentifiers.APIC);
         header.frameSize = 34;
         const data = ByteVector.concatenate(
             header.render(2),
+            0x00, 0x00,
             StringType.UTF16BE,
             ByteVector.fromString("GIF", StringType.Latin1),
             PictureType.Artist,
@@ -224,7 +195,7 @@ const getCustomTestFrame = (
         );
 
         // Act
-        const frame = AttachmentFrame.fromRawData(data, 2);
+        const frame = AttachmentFrame.fromOffsetRawData(data, 2, header, 2);
 
         // Assert
         Id3v2_AttachmentFrame_ConstructorTests.verifyFrame(
@@ -240,13 +211,14 @@ const getCustomTestFrame = (
     }
 
     @test
-    public fromRawData_geob_nonLatinEncoding() {
+    public fromOffsetRawData_geob_nonLatinEncoding() {
         // Arrange
         const testData = ByteVector.fromString("fuxbuxqux", StringType.Latin1);
         const header = new Id3v2FrameHeader(FrameIdentifiers.GEOB);
         header.frameSize = 60;
         const data = ByteVector.concatenate(
             header.render(4),
+            0x00, 0x00,
             StringType.UTF16BE,
             ByteVector.fromString("image/gif", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),
@@ -258,7 +230,7 @@ const getCustomTestFrame = (
         );
 
         // Act
-        const frame = AttachmentFrame.fromRawData(data, 4);
+        const frame = AttachmentFrame.fromOffsetRawData(data, 2, header, 4);
 
         // Assert
         Id3v2_AttachmentFrame_ConstructorTests.verifyFrame(
@@ -274,13 +246,14 @@ const getCustomTestFrame = (
     }
 
     @test
-    public fromRawData_geob_latinEncoding() {
+    public fromOffsetRawData_geob_latinEncoding() {
         // Arrange
         const testData = ByteVector.fromString("fuxbuxqux", StringType.Latin1);
         const header = new Id3v2FrameHeader(FrameIdentifiers.GEOB);
         header.frameSize = 60;
         const data = ByteVector.concatenate(
             header.render(4),
+            0x00, 0x00,
             StringType.Latin1,
             ByteVector.fromString("image/gif", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),
@@ -292,7 +265,7 @@ const getCustomTestFrame = (
         );
 
         // Act
-        const frame = AttachmentFrame.fromRawData(data, 4);
+        const frame = AttachmentFrame.fromOffsetRawData(data, 2, header, 4);
 
         // Assert
         Id3v2_AttachmentFrame_ConstructorTests.verifyFrame(
@@ -505,13 +478,14 @@ const getCustomTestFrame = (
     }
 
     @test
-    public clone_fromRawDataUnread() {
+    public clone_fromOffsetRawDataUnread() {
         // Arrange
         const testData = ByteVector.fromString("fuxbuxqux", StringType.Latin1);
         const header = new Id3v2FrameHeader(FrameIdentifiers.APIC);
         header.frameSize = 41;
         const data = ByteVector.concatenate(
             header.render(4),
+            0x00, 0x00,
             StringType.UTF16BE,
             ByteVector.fromString("image/gif", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),
@@ -520,7 +494,7 @@ const getCustomTestFrame = (
             ByteVector.getTextDelimiter(StringType.UTF16BE),
             testData
         );
-        const frame = AttachmentFrame.fromRawData(data, 4);
+        const frame = AttachmentFrame.fromOffsetRawData(data, 2, header, 4);
 
         // Act
         const output = <AttachmentFrame> frame.clone();

--- a/test-unit/id3v2/attachmentsFrameTests.ts
+++ b/test-unit/id3v2/attachmentsFrameTests.ts
@@ -42,7 +42,6 @@ const getCustomTestFrame = (
     get fromOffsetRawData(): (d: ByteVector, o: number, h: Id3v2FrameHeader, v: number) => Frame {
         return AttachmentFrame.fromOffsetRawData;
     }
-    get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
 
     @test
     public fromPicture_falsyPicture() {

--- a/test-unit/id3v2/attachmentsFrameTests.ts
+++ b/test-unit/id3v2/attachmentsFrameTests.ts
@@ -116,8 +116,8 @@ const getCustomTestFrame = (
         const header = new Id3v2FrameHeader(FrameIdentifiers.APIC);
         header.frameSize = 41;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             StringType.Latin1,
             ByteVector.fromString("image/gif", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),
@@ -150,8 +150,8 @@ const getCustomTestFrame = (
         const header = new Id3v2FrameHeader(FrameIdentifiers.APIC);
         header.frameSize = 41;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             StringType.UTF16BE,
             ByteVector.fromString("image/gif", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),
@@ -184,8 +184,8 @@ const getCustomTestFrame = (
         const header = new Id3v2FrameHeader(FrameIdentifiers.APIC);
         header.frameSize = 34;
         const data = ByteVector.concatenate(
-            header.render(2),
             0x00, 0x00,
+            header.render(2),
             StringType.UTF16BE,
             ByteVector.fromString("GIF", StringType.Latin1),
             PictureType.Artist,
@@ -217,8 +217,8 @@ const getCustomTestFrame = (
         const header = new Id3v2FrameHeader(FrameIdentifiers.GEOB);
         header.frameSize = 60;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             StringType.UTF16BE,
             ByteVector.fromString("image/gif", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),
@@ -252,8 +252,8 @@ const getCustomTestFrame = (
         const header = new Id3v2FrameHeader(FrameIdentifiers.GEOB);
         header.frameSize = 60;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             StringType.Latin1,
             ByteVector.fromString("image/gif", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),
@@ -287,8 +287,8 @@ const getCustomTestFrame = (
         const header = new Id3v2FrameHeader(FrameIdentifiers.APIC);
         header.frameSize = 41;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             StringType.UTF16BE,
             ByteVector.fromString("image/gif", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),
@@ -484,8 +484,8 @@ const getCustomTestFrame = (
         const header = new Id3v2FrameHeader(FrameIdentifiers.APIC);
         header.frameSize = 41;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             StringType.UTF16BE,
             ByteVector.fromString("image/gif", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),

--- a/test-unit/id3v2/commentsFrameTests.ts
+++ b/test-unit/id3v2/commentsFrameTests.ts
@@ -23,7 +23,7 @@ const getTestFrame = (): CommentsFrame => {
         ByteVector.fromString("bar", StringType.Latin1)
     );
 
-    return CommentsFrame.fromRawData(data, 4);
+    return CommentsFrame.fromOffsetRawData(data, 0, header, 4);
 }
 
 @suite class Id3v2_CommentsFrame_ConstructorTests extends FrameConstructorTests {
@@ -31,9 +31,7 @@ const getTestFrame = (): CommentsFrame => {
         return CommentsFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame {
-        return CommentsFrame.fromRawData;
-    }
+    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
 
     @test
     public fromDescription_falsyDescription() {
@@ -185,98 +183,6 @@ const getTestFrame = (): CommentsFrame => {
 
         // Act
         const frame = CommentsFrame.fromOffsetRawData(data, 2, header, 4);
-
-        // Assert
-        Id3v2_CommentsFrame_ConstructorTests.validateFrame(frame, "fux", "eng", StringType.Latin1, "bux");
-    }
-
-    @test
-    public fromRawData_tooFewBytes_throws() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.COMM);
-        header.frameSize = 1;
-        const data = ByteVector.concatenate(
-            header.render(4),
-            StringType.Latin1
-        );
-
-        // Act/Assert
-        assert.throws(() => { CommentsFrame.fromRawData(data, 4); });
-    }
-
-    @test
-    public fromRawData_noData_returnsEmptyFrame() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.COMM);
-        header.frameSize = 4;
-        const data = ByteVector.concatenate(
-            header.render(4),
-            StringType.Latin1,
-            ByteVector.fromString("eng", StringType.Latin1)
-        );
-
-        // Act
-        const frame = CommentsFrame.fromRawData(data, 4);
-
-        // Assert
-        Id3v2_CommentsFrame_ConstructorTests.validateFrame(frame, "", "eng", StringType.Latin1, "");
-    }
-
-    @test
-    public fromRawData_oneData_returnsFrameWithoutDescription() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.COMM);
-        header.frameSize = 7;
-        const data = ByteVector.concatenate(
-            header.render(4),
-            StringType.Latin1,
-            ByteVector.fromString("eng", StringType.Latin1),
-            ByteVector.fromString("fux", StringType.Latin1),
-        );
-
-        // Act
-        const frame = CommentsFrame.fromRawData(data, 4);
-
-        // Assert
-        Id3v2_CommentsFrame_ConstructorTests.validateFrame(frame, "", "eng", StringType.Latin1, "fux");
-    }
-
-    @test
-    public fromRawData_twoData_returnsFrameWithDescriptionAndText() {
-        const header = new Id3v2FrameHeader(FrameIdentifiers.COMM);
-        header.frameSize = 11;
-        const data = ByteVector.concatenate(
-            header.render(4),
-            StringType.Latin1,
-            ByteVector.fromString("eng", StringType.Latin1),
-            ByteVector.fromString("fux", StringType.Latin1),
-            ByteVector.getTextDelimiter(StringType.Latin1),
-            ByteVector.fromString("bux", StringType.Latin1)
-        );
-
-        // Act
-        const frame = CommentsFrame.fromRawData(data, 4);
-
-        // Assert
-        Id3v2_CommentsFrame_ConstructorTests.validateFrame(frame, "fux", "eng", StringType.Latin1, "bux");
-    }
-
-    @test
-    public fromRawData_threeData_returnsFrameWithDescriptionAndText() {
-        const header = new Id3v2FrameHeader(FrameIdentifiers.COMM);
-        header.frameSize = 12;
-        const data = ByteVector.concatenate(
-            header.render(4),
-            StringType.Latin1,
-            ByteVector.fromString("eng", StringType.Latin1),
-            ByteVector.fromString("fux", StringType.Latin1),
-            ByteVector.getTextDelimiter(StringType.Latin1),
-            ByteVector.fromString("bux", StringType.Latin1),
-            ByteVector.getTextDelimiter(StringType.Latin1)
-        );
-
-        // Act
-        const frame = CommentsFrame.fromRawData(data, 4);
 
         // Assert
         Id3v2_CommentsFrame_ConstructorTests.validateFrame(frame, "fux", "eng", StringType.Latin1, "bux");
@@ -576,7 +482,7 @@ const getTestFrame = (): CommentsFrame => {
             ByteVector.getTextDelimiter(StringType.Latin1),
             ByteVector.fromString("bux", StringType.Latin1)
         );
-        const frame = CommentsFrame.fromRawData(data, 4);
+        const frame = CommentsFrame.fromOffsetRawData(data, 0, header, 4);
 
         // Act
         const output = frame.render(4);

--- a/test-unit/id3v2/commentsFrameTests.ts
+++ b/test-unit/id3v2/commentsFrameTests.ts
@@ -31,8 +31,6 @@ const getTestFrame = (): CommentsFrame => {
         return CommentsFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
-
     @test
     public fromDescription_falsyDescription() {
         // Act/Assert

--- a/test-unit/id3v2/commentsFrameTests.ts
+++ b/test-unit/id3v2/commentsFrameTests.ts
@@ -96,8 +96,8 @@ const getTestFrame = (): CommentsFrame => {
         const header = new Id3v2FrameHeader(FrameIdentifiers.COMM);
         header.frameSize = 1;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             StringType.Latin1
         );
 
@@ -111,8 +111,8 @@ const getTestFrame = (): CommentsFrame => {
         const header = new Id3v2FrameHeader(FrameIdentifiers.COMM);
         header.frameSize = 4;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             StringType.Latin1,
             ByteVector.fromString("eng", StringType.Latin1)
         );
@@ -130,8 +130,8 @@ const getTestFrame = (): CommentsFrame => {
         const header = new Id3v2FrameHeader(FrameIdentifiers.COMM);
         header.frameSize = 7;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             StringType.Latin1,
             ByteVector.fromString("eng", StringType.Latin1),
             ByteVector.fromString("fux", StringType.Latin1)
@@ -150,8 +150,8 @@ const getTestFrame = (): CommentsFrame => {
         const header = new Id3v2FrameHeader(FrameIdentifiers.COMM);
         header.frameSize = 11;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             StringType.Latin1,
             ByteVector.fromString("eng", StringType.Latin1),
             ByteVector.fromString("fux", StringType.Latin1),
@@ -171,9 +171,9 @@ const getTestFrame = (): CommentsFrame => {
         const header = new Id3v2FrameHeader(FrameIdentifiers.COMM);
         header.frameSize = 12;
         const data = ByteVector.concatenate(
+            0x00, 0x00,
             header.render(4),
             StringType.Latin1,
-            0x00, 0x00,
             ByteVector.fromString("eng", StringType.Latin1),
             ByteVector.fromString("fux", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),

--- a/test-unit/id3v2/eventTimeCodeFrameTests.ts
+++ b/test-unit/id3v2/eventTimeCodeFrameTests.ts
@@ -92,8 +92,6 @@ import {EventType, TimestampFormat} from "../../src/id3v2/utilTypes";
         return EventTimeCodeFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
-
     @test
     public fromEmpty() {
         // Act

--- a/test-unit/id3v2/eventTimeCodeFrameTests.ts
+++ b/test-unit/id3v2/eventTimeCodeFrameTests.ts
@@ -92,9 +92,7 @@ import {EventType, TimestampFormat} from "../../src/id3v2/utilTypes";
         return EventTimeCodeFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame {
-        return EventTimeCodeFrame.fromRawData;
-    }
+    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
 
     @test
     public fromEmpty() {
@@ -112,48 +110,6 @@ import {EventType, TimestampFormat} from "../../src/id3v2/utilTypes";
 
         // Assert
         Id3v2_EventTimeCodeFrame_ConstructorTests.assertFrame(output, [], TimestampFormat.AbsoluteMilliseconds);
-    }
-
-    @test
-    public fromRawData_noEvents() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.ETCO);
-        header.frameSize = 1;
-        const data = ByteVector.concatenate(
-            header.render(4),
-            TimestampFormat.AbsoluteMilliseconds
-        );
-
-        // Act
-        const frame = EventTimeCodeFrame.fromRawData(data, 4);
-
-        // Assert
-        Id3v2_EventTimeCodeFrame_ConstructorTests.assertFrame(frame, [], TimestampFormat.AbsoluteMilliseconds);
-    }
-
-    @test
-    public fromRawData_withEvents() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.ETCO);
-        header.frameSize = 11;
-        const event1 = new EventTimeCode(EventType.Profanity, 123);
-        const event2 = new EventTimeCode(EventType.KeyChange, 456);
-        const data = ByteVector.concatenate(
-            header.render(4),
-            TimestampFormat.AbsoluteMilliseconds,
-            event1.render(),
-            event2.render()
-        );
-
-        // Act
-        const frame = EventTimeCodeFrame.fromRawData(data, 4);
-
-        // Assert
-        Id3v2_EventTimeCodeFrame_ConstructorTests.assertFrame(
-            frame,
-            [event1, event2],
-            TimestampFormat.AbsoluteMilliseconds
-        );
     }
 
     @test
@@ -275,7 +231,7 @@ import {EventType, TimestampFormat} from "../../src/id3v2/utilTypes";
             event2.render(),    // Force events to be sorted
             event1.render()
         );
-        const frame = EventTimeCodeFrame.fromRawData(data, 4);
+        const frame = EventTimeCodeFrame.fromOffsetRawData(data, 0, header, 4);
 
         // Act
         const output = frame.render(4);

--- a/test-unit/id3v2/eventTimeCodeFrameTests.ts
+++ b/test-unit/id3v2/eventTimeCodeFrameTests.ts
@@ -118,8 +118,8 @@ import {EventType, TimestampFormat} from "../../src/id3v2/utilTypes";
         const header = new Id3v2FrameHeader(FrameIdentifiers.ETCO);
         header.frameSize = 1;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             TimestampFormat.AbsoluteMilliseconds
         );
 
@@ -138,8 +138,8 @@ import {EventType, TimestampFormat} from "../../src/id3v2/utilTypes";
         const event1 = new EventTimeCode(EventType.Profanity, 123);
         const event2 = new EventTimeCode(EventType.KeyChange, 456);
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             TimestampFormat.AbsoluteMilliseconds,
             event1.render(),
             event2.render()

--- a/test-unit/id3v2/frameConstructorTests.ts
+++ b/test-unit/id3v2/frameConstructorTests.ts
@@ -9,7 +9,6 @@ import {Testers} from "../utilities/testers";
 export default abstract class FrameConstructorTests {
 
     public abstract get fromOffsetRawData(): (d: ByteVector, o: number, h: Id3v2FrameHeader, v: number) => Frame;
-    public abstract get fromRawData(): (d: ByteVector, v: number) => Frame;
 
     @test
     public fromOffsetRawData_falsyData_throws() {
@@ -37,20 +36,5 @@ export default abstract class FrameConstructorTests {
 
         // Act/Assert
         Testers.testTruthy((v: Id3v2FrameHeader) => { this.fromOffsetRawData(data, 2, v, 4); });
-    }
-
-    @test
-    public fromRawData_falsyData_throws() {
-        // Act/Assert
-        Testers.testTruthy((v: ByteVector) => { this.fromRawData(v, 2); });
-    }
-
-    @test
-    public fromRawData_invalidVersion_throws() {
-        // Arrange
-        const data = ByteVector.empty();
-
-        // Act/Assert
-        Testers.testByte((v: number) => { this.fromRawData(data, v); });
     }
 }

--- a/test-unit/id3v2/musicCdIdentifierFrameTests.ts
+++ b/test-unit/id3v2/musicCdIdentifierFrameTests.ts
@@ -15,8 +15,6 @@ import {Testers} from "../utilities/testers";
         return MusicCdIdentifierFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
-
     @test
     public fromOffsetRawData_validParameters() {
         // Arrange

--- a/test-unit/id3v2/musicCdIdentifierFrameTests.ts
+++ b/test-unit/id3v2/musicCdIdentifierFrameTests.ts
@@ -23,8 +23,8 @@ import {Testers} from "../utilities/testers";
         const header = new Id3v2FrameHeader(FrameIdentifiers.MCDI);
         header.frameSize = 9;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             ByteVector.fromString("12345abcd", StringType.Latin1)
         );
 

--- a/test-unit/id3v2/musicCdIdentifierFrameTests.ts
+++ b/test-unit/id3v2/musicCdIdentifierFrameTests.ts
@@ -15,26 +15,7 @@ import {Testers} from "../utilities/testers";
         return MusicCdIdentifierFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame {
-        return MusicCdIdentifierFrame.fromRawData;
-    }
-
-    @test
-    public fromRawData_validParameters() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.MCDI);
-        header.frameSize = 9;
-        const data = ByteVector.concatenate(
-            header.render(4),
-            ByteVector.fromString("12345abcd", StringType.Latin1)
-        );
-
-        // Act
-        const frame = MusicCdIdentifierFrame.fromRawData(data, 4);
-
-        // Assert
-        Id3v2_MusicCdIdentifierFrameTests.assertFrame(frame, ByteVector.fromString("12345abcd", StringType.Latin1));
-    }
+    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
 
     @test
     public fromOffsetRawData_validParameters() {
@@ -82,7 +63,7 @@ import {Testers} from "../utilities/testers";
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.MCDI);
         header.frameSize = 0;
-        const frame = MusicCdIdentifierFrame.fromRawData(header.render(4), 4);
+        const frame = MusicCdIdentifierFrame.fromOffsetRawData(header.render(4), 0, header, 4);
 
         // Act
         const output = <MusicCdIdentifierFrame> frame.clone();
@@ -100,7 +81,7 @@ import {Testers} from "../utilities/testers";
             header.render(4),
             ByteVector.fromString("12345abcd", StringType.Latin1)
         );
-        const frame = MusicCdIdentifierFrame.fromRawData(data, 4);
+        const frame = MusicCdIdentifierFrame.fromOffsetRawData(data, 0, header, 4);
 
         // Act
         const output = frame.render(4);
@@ -114,7 +95,7 @@ import {Testers} from "../utilities/testers";
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.MCDI);
         header.frameSize = 0;
-        const frame = MusicCdIdentifierFrame.fromRawData(header.render(4), 4);
+        const frame = MusicCdIdentifierFrame.fromOffsetRawData(header.render(4), 0, header, 4);
 
         // Act
         const output = frame.render(4);
@@ -138,6 +119,6 @@ import {Testers} from "../utilities/testers";
             header.render(4),
             ByteVector.fromString("12345abcd", StringType.Latin1)
         );
-        return MusicCdIdentifierFrame.fromRawData(data, 4);
+        return MusicCdIdentifierFrame.fromOffsetRawData(data, 0, header, 4);
     }
 }

--- a/test-unit/id3v2/playCountFrameTests.ts
+++ b/test-unit/id3v2/playCountFrameTests.ts
@@ -15,9 +15,7 @@ import {Testers} from "../utilities/testers";
         return PlayCountFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame {
-        return PlayCountFrame.fromRawData;
-    }
+    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
 
     @test
     public fromEmpty() {
@@ -29,51 +27,54 @@ import {Testers} from "../utilities/testers";
     }
 
     @test
-    public fromRawData_fourBytePlayCount() {
+    public fromOffsetRawData_fourBytePlayCount() {
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.PCNT);
         header.frameSize = 4;
         const data = ByteVector.concatenate(
             header.render(4),
+            0x00, 0x00,
             ByteVector.fromUint(1234)
         );
 
         // Act
-        const frame = PlayCountFrame.fromRawData(data, 4);
+        const frame = PlayCountFrame.fromOffsetRawData(data, 2, header, 4);
 
         // Assert
         this.assertFrame(frame, BigInt(1234));
     }
 
     @test
-    public fromRawData_sixBytePlayCount() {
+    public fromOffsetRawData_sixBytePlayCount() {
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.PCNT);
         header.frameSize = 6;
         const data = ByteVector.concatenate(
             header.render(4),
+            0x00, 0x00,
             0x00, 0x00, ByteVector.fromUint(1234)
         );
 
         // Act
-        const frame = PlayCountFrame.fromRawData(data, 4);
+        const frame = PlayCountFrame.fromOffsetRawData(data, 2, header, 4);
 
         // Assert
         this.assertFrame(frame, BigInt(1234));
     }
 
     @test
-    public fromRawData_eightBytePlayCount() {
+    public fromOffsetRawData_eightBytePlayCount() {
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.PCNT);
         header.frameSize = 8;
         const data = ByteVector.concatenate(
             header.render(4),
+            0x00, 0x00,
             ByteVector.fromUlong(BigInt("4294967296"))
         );
 
         // Act
-        const frame = PlayCountFrame.fromRawData(data, 4);
+        const frame = PlayCountFrame.fromOffsetRawData(data, 2, header, 4);
 
         // Assert
         this.assertFrame(frame, BigInt("4294967296"));
@@ -149,7 +150,7 @@ import {Testers} from "../utilities/testers";
             header.render(4),
             ByteVector.fromUint(1234)
         );
-        const frame = PlayCountFrame.fromRawData(data, 4);
+        const frame = PlayCountFrame.fromOffsetRawData(data, 0, header, 4);
 
         // Act
         const output = frame.render(4);
@@ -168,7 +169,7 @@ import {Testers} from "../utilities/testers";
             header.render(4),
             0x12, 0x34, 0x45, 0x56, 0x78, 0x90
         );
-        const frame = PlayCountFrame.fromRawData(data, 4);
+        const frame = PlayCountFrame.fromOffsetRawData(data, 0, header, 4);
 
         // Act
         const output = frame.render(4);
@@ -187,7 +188,7 @@ import {Testers} from "../utilities/testers";
             header.render(4),
             0x12, 0x34, 0x45, 0x56, 0x78, 0x90, 0xAB, 0xCD
         );
-        const frame = PlayCountFrame.fromRawData(data, 4);
+        const frame = PlayCountFrame.fromOffsetRawData(data, 0, header, 4);
 
         // Act
         const output = frame.render(4);

--- a/test-unit/id3v2/playCountFrameTests.ts
+++ b/test-unit/id3v2/playCountFrameTests.ts
@@ -15,8 +15,6 @@ import {Testers} from "../utilities/testers";
         return PlayCountFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
-
     @test
     public fromEmpty() {
         // Act

--- a/test-unit/id3v2/playCountFrameTests.ts
+++ b/test-unit/id3v2/playCountFrameTests.ts
@@ -32,8 +32,8 @@ import {Testers} from "../utilities/testers";
         const header = new Id3v2FrameHeader(FrameIdentifiers.PCNT);
         header.frameSize = 4;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             ByteVector.fromUint(1234)
         );
 
@@ -50,8 +50,8 @@ import {Testers} from "../utilities/testers";
         const header = new Id3v2FrameHeader(FrameIdentifiers.PCNT);
         header.frameSize = 6;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             0x00, 0x00, ByteVector.fromUint(1234)
         );
 
@@ -68,8 +68,8 @@ import {Testers} from "../utilities/testers";
         const header = new Id3v2FrameHeader(FrameIdentifiers.PCNT);
         header.frameSize = 8;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             ByteVector.fromUlong(BigInt("4294967296"))
         );
 
@@ -86,8 +86,8 @@ import {Testers} from "../utilities/testers";
         const header = new Id3v2FrameHeader(FrameIdentifiers.PCNT);
         header.frameSize = 8;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             ByteVector.fromUlong(BigInt("4294967296"))
         );
 

--- a/test-unit/id3v2/popularimeterFrameTests.ts
+++ b/test-unit/id3v2/popularimeterFrameTests.ts
@@ -15,9 +15,7 @@ import {Testers} from "../utilities/testers";
         return PopularimeterFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame {
-        return PopularimeterFrame.fromRawData;
-    }
+    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
 
     @test
     public fromUser() {
@@ -29,60 +27,64 @@ import {Testers} from "../utilities/testers";
     }
 
     @test
-    public fromRawData_noDelimiter() {
+    public fromOffsetRawData_noDelimiter() {
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.POPM);
         header.frameSize = 3;
         const data = ByteVector.concatenate(
             header.render(4),
+            0x00, 0x00,
             0x01, 0x02, 0x03
         );
 
         // Act / Assert
-        assert.throws(() => { PopularimeterFrame.fromRawData(data, 4); });
+        assert.throws(() => { PopularimeterFrame.fromOffsetRawData(data, 2, header, 4); });
     }
 
     @test
-    public fromRawData_tooShort() {
+    public fromOffsetRawData_tooShort() {
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.POPM);
         header.frameSize = 3;
         const data = ByteVector.concatenate(
             header.render(4),
+            0x00, 0x00,
             0x01,
             ByteVector.getTextDelimiter(StringType.Latin1)
         );
 
         // Act / Assert
-        assert.throws(() => { PopularimeterFrame.fromRawData(data, 4); });
+        assert.throws(() => { PopularimeterFrame.fromOffsetRawData(data, 2, header, 4); });
     }
 
     @test
-    public fromRawData_noPlayCount() {
+    public fromOffsetRawData_noPlayCount() {
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.POPM);
         header.frameSize = 9;
         const data = ByteVector.concatenate(
             header.render(4),
+            0x00, 0x00,
             ByteVector.fromString("fux", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),
             0x05
         );
 
         // Act
-        const frame = PopularimeterFrame.fromRawData(data, 4);
+        const frame = PopularimeterFrame.fromOffsetRawData(data, 2, header, 4);
 
         // Assert
         this.assertFrame(frame, "fux", undefined, 0x05);
     }
 
     @test
-    public fromRawData_invalidPlayCountBytes() {
+    public fromOffsetRawData_invalidPlayCountBytes() {
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.POPM);
         header.frameSize = 9;
         const data = ByteVector.concatenate(
             header.render(4),
+            0x00, 0x00,
             ByteVector.fromString("fux", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),
             0x05,
@@ -90,16 +92,17 @@ import {Testers} from "../utilities/testers";
         );
 
         // Act / Assert
-        assert.throws(() => { PopularimeterFrame.fromRawData(data, 4); });
+        assert.throws(() => { PopularimeterFrame.fromOffsetRawData(data, 2, header, 4); });
     }
 
     @test
-    public fromRawData_intSizedPlayCount() {
+    public fromOffsetRawData_intSizedPlayCount() {
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.POPM);
         header.frameSize = 9;
         const data = ByteVector.concatenate(
             header.render(4),
+            0x00, 0x00,
             ByteVector.fromString("fux", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),
             0x05,
@@ -107,27 +110,7 @@ import {Testers} from "../utilities/testers";
         );
 
         // Act
-        const frame = PopularimeterFrame.fromRawData(data, 4);
-
-        // Assert
-        this.assertFrame(frame, "fux", BigInt(1234), 0x05);
-    }
-
-    @test
-    public fromRawData_longSizedPlayCount() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.POPM);
-        header.frameSize = 13;
-        const data = ByteVector.concatenate(
-            header.render(4),
-            ByteVector.fromString("fux", StringType.Latin1),
-            ByteVector.getTextDelimiter(StringType.Latin1),
-            0x05,
-            ByteVector.fromUlong(BigInt(1234))
-        );
-
-        // Act
-        const frame = PopularimeterFrame.fromRawData(data, 4);
+        const frame = PopularimeterFrame.fromOffsetRawData(data, 2, header, 4);
 
         // Assert
         this.assertFrame(frame, "fux", BigInt(1234), 0x05);
@@ -293,7 +276,7 @@ import {Testers} from "../utilities/testers";
             ByteVector.getTextDelimiter(StringType.Latin1),
             0x05
         );
-        const frame = PopularimeterFrame.fromRawData(data, 4);
+        const frame = PopularimeterFrame.fromOffsetRawData(data, 0, header, 4);
 
         // Act
         const output = frame.render(4);
@@ -315,7 +298,7 @@ import {Testers} from "../utilities/testers";
             0x05,
             ByteVector.fromUint(1234)
         );
-        const frame = PopularimeterFrame.fromRawData(data, 4);
+        const frame = PopularimeterFrame.fromOffsetRawData(data, 0, header, 4);
 
         // Act
         const output = frame.render(4);
@@ -337,7 +320,7 @@ import {Testers} from "../utilities/testers";
             0x05,
             0x01, 0x02, 0x03, 0x04, 0x05
         );
-        const frame = PopularimeterFrame.fromRawData(data, 4);
+        const frame = PopularimeterFrame.fromOffsetRawData(data, 0, header, 4);
 
         // Act
         const output = frame.render(4);
@@ -359,7 +342,7 @@ import {Testers} from "../utilities/testers";
             0x05,
             0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
         );
-        const frame = PopularimeterFrame.fromRawData(data, 4);
+        const frame = PopularimeterFrame.fromOffsetRawData(data, 0, header, 4);
 
         // Act
         const output = frame.render(4);
@@ -369,4 +352,3 @@ import {Testers} from "../utilities/testers";
         Testers.bvEqual(output, data);
     }
 }
-

--- a/test-unit/id3v2/popularimeterFrameTests.ts
+++ b/test-unit/id3v2/popularimeterFrameTests.ts
@@ -32,8 +32,8 @@ import {Testers} from "../utilities/testers";
         const header = new Id3v2FrameHeader(FrameIdentifiers.POPM);
         header.frameSize = 3;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             0x01, 0x02, 0x03
         );
 
@@ -47,8 +47,8 @@ import {Testers} from "../utilities/testers";
         const header = new Id3v2FrameHeader(FrameIdentifiers.POPM);
         header.frameSize = 3;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             0x01,
             ByteVector.getTextDelimiter(StringType.Latin1)
         );
@@ -63,8 +63,8 @@ import {Testers} from "../utilities/testers";
         const header = new Id3v2FrameHeader(FrameIdentifiers.POPM);
         header.frameSize = 9;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             ByteVector.fromString("fux", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),
             0x05
@@ -83,8 +83,8 @@ import {Testers} from "../utilities/testers";
         const header = new Id3v2FrameHeader(FrameIdentifiers.POPM);
         header.frameSize = 9;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             ByteVector.fromString("fux", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),
             0x05,
@@ -101,8 +101,8 @@ import {Testers} from "../utilities/testers";
         const header = new Id3v2FrameHeader(FrameIdentifiers.POPM);
         header.frameSize = 9;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             ByteVector.fromString("fux", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),
             0x05,
@@ -122,8 +122,8 @@ import {Testers} from "../utilities/testers";
         const header = new Id3v2FrameHeader(FrameIdentifiers.POPM);
         header.frameSize = 13;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             ByteVector.fromString("fux", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),
             0x05,

--- a/test-unit/id3v2/popularimeterFrameTests.ts
+++ b/test-unit/id3v2/popularimeterFrameTests.ts
@@ -15,8 +15,6 @@ import {Testers} from "../utilities/testers";
         return PopularimeterFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
-
     @test
     public fromUser() {
         // Act

--- a/test-unit/id3v2/privateFrameTests.ts
+++ b/test-unit/id3v2/privateFrameTests.ts
@@ -15,8 +15,6 @@ import {Testers} from "../utilities/testers";
         return PrivateFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
-
     @test
     public fromOwner() {
         // Act

--- a/test-unit/id3v2/privateFrameTests.ts
+++ b/test-unit/id3v2/privateFrameTests.ts
@@ -32,8 +32,8 @@ import {Testers} from "../utilities/testers";
         const header = new Id3v2FrameHeader(FrameIdentifiers.PRIV);
         header.frameSize = 0;
         const data = ByteVector.concatenate(
-            header.render(4),
-            0x00, 0x00
+            0x00, 0x00,
+            header.render(4)
         );
 
         // Act / Assert
@@ -46,8 +46,8 @@ import {Testers} from "../utilities/testers";
         const header = new Id3v2FrameHeader(FrameIdentifiers.PRIV);
         header.frameSize = 4;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             ByteVector.fromString("fux", StringType.Latin1)
         );
 
@@ -64,8 +64,8 @@ import {Testers} from "../utilities/testers";
         const header = new Id3v2FrameHeader(FrameIdentifiers.PRIV);
         header.frameSize = 8;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             ByteVector.fromString("fux", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),
             0x01, 0x02, 0x03, 0x04

--- a/test-unit/id3v2/privateFrameTests.ts
+++ b/test-unit/id3v2/privateFrameTests.ts
@@ -15,9 +15,7 @@ import {Testers} from "../utilities/testers";
         return PrivateFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame {
-        return PrivateFrame.fromRawData;
-    }
+    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
 
     @test
     public fromOwner() {
@@ -29,56 +27,35 @@ import {Testers} from "../utilities/testers";
     }
 
     @test
-    public fromRawData_tooFewBytes() {
+    public fromOffsetRawData_tooFewBytes() {
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.PRIV);
         header.frameSize = 0;
         const data = ByteVector.concatenate(
-            header.render(4)
+            header.render(4),
+            0x00, 0x00
         );
 
         // Act / Assert
-        assert.throws(() => { PrivateFrame.fromRawData(data, 4); });
+        assert.throws(() => { PrivateFrame.fromOffsetRawData(data, 2, header, 4); });
     }
 
     @test
-    public fromRawData_owner() {
+    public fromOffsetRawData_owner() {
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.PRIV);
         header.frameSize = 4;
         const data = ByteVector.concatenate(
             header.render(4),
+            0x00, 0x00,
             ByteVector.fromString("fux", StringType.Latin1)
         );
 
         // Act
-        const frame = PrivateFrame.fromRawData(data, 4);
+        const frame = PrivateFrame.fromOffsetRawData(data, 2, header, 4);
 
         // Assert
         Id3v2_PrivateFrame_ConstructorTests.assertFrame(frame, "fux", ByteVector.empty());
-    }
-
-    @test
-    public fromRawData_ownerAndData() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.PRIV);
-        header.frameSize = 9;
-        const data = ByteVector.concatenate(
-            header.render(4),
-            ByteVector.fromString("fux", StringType.Latin1),
-            ByteVector.getTextDelimiter(StringType.Latin1),
-            0x01, 0x02, 0x03, 0x04
-        );
-
-        // Act
-        const frame = PrivateFrame.fromRawData(data, 4);
-
-        // Assert
-        Id3v2_PrivateFrame_ConstructorTests.assertFrame(
-            frame,
-            "fux",
-            ByteVector.fromByteArray(new Uint8Array([0x01, 0x02, 0x03, 0x04]))
-        );
     }
 
     @test
@@ -203,7 +180,7 @@ import {Testers} from "../utilities/testers";
             ByteVector.getTextDelimiter(StringType.Latin1),
             0x01, 0x02, 0x03, 0x04
         );
-        const frame = PrivateFrame.fromRawData(data, 4);
+        const frame = PrivateFrame.fromOffsetRawData(data, 0, header, 4);
 
         // Act
         const output = frame.render(4);
@@ -224,7 +201,7 @@ import {Testers} from "../utilities/testers";
             ByteVector.getTextDelimiter(StringType.Latin1),
             0x01, 0x02, 0x03, 0x04
         );
-        const frame = PrivateFrame.fromRawData(data, 4);
+        const frame = PrivateFrame.fromOffsetRawData(data, 0, header, 4);
 
         // Act / Assert
         assert.throws(() => frame.render(2));

--- a/test-unit/id3v2/relativeVolumeFrameTests.ts
+++ b/test-unit/id3v2/relativeVolumeFrameTests.ts
@@ -277,9 +277,7 @@ import {Testers} from "../utilities/testers";
         return RelativeVolumeFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame {
-        return RelativeVolumeFrame.fromRawData;
-    }
+    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
 
     @test
     public fromIdentification() {
@@ -291,51 +289,21 @@ import {Testers} from "../utilities/testers";
     }
 
     @test
-    public fromRawData_noDelimiter_emptyFrame() {
+    public fromOffsetRawData_noDelimiter_emptyFrame() {
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.RVA2);
         header.frameSize = 3;
         const data = ByteVector.concatenate(
             header.render(4),
+            0x00, 0x00,
             ByteVector.fromString("foo", StringType.Latin1)
         );
 
         // Act
-        const frame = RelativeVolumeFrame.fromRawData(data, 4);
+        const frame = RelativeVolumeFrame.fromOffsetRawData(data, 2, header, 4);
 
         // Assert
         Id3v2_RelativeVolumeFrame_ConstructorTests.assertFrame(frame, [], undefined);
-    }
-
-    @test
-    public fromRawData_withChannelData_hasChannelData() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.RVA2);
-        header.frameSize = 15;
-
-        const channel1 = new ChannelData(ChannelType.Subwoofer);
-        channel1.volumeAdjustment = 32;
-        channel1.peakBits = 8;
-        channel1.peakVolume = BigInt(12);
-
-        const channel2 = new ChannelData(ChannelType.BackCenter);
-        channel2.volumeAdjustment = 62;
-        channel2.peakBits = 16;
-        channel2.peakVolume = BigInt(123);
-
-        const data = ByteVector.concatenate(
-            header.render(4),
-            ByteVector.fromString("foo", StringType.Latin1),
-            ByteVector.getTextDelimiter(StringType.Latin1),
-            channel1.render(),
-            channel2.render()
-        );
-
-        // Act
-        const frame = RelativeVolumeFrame.fromRawData(data, 4);
-
-        // Assert
-        Id3v2_RelativeVolumeFrame_ConstructorTests.assertFrame(frame, [channel2, channel1], "foo");
     }
 
     @test
@@ -482,7 +450,7 @@ import {Testers} from "../utilities/testers";
             channel2.render(),
             channel1.render()
         );
-        const frame = RelativeVolumeFrame.fromRawData(data, 4);
+        const frame = RelativeVolumeFrame.fromOffsetRawData(data, 0, header, 4);
 
         // Act
         const output = frame.render(4);

--- a/test-unit/id3v2/relativeVolumeFrameTests.ts
+++ b/test-unit/id3v2/relativeVolumeFrameTests.ts
@@ -294,8 +294,8 @@ import {Testers} from "../utilities/testers";
         const header = new Id3v2FrameHeader(FrameIdentifiers.RVA2);
         header.frameSize = 3;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             ByteVector.fromString("foo", StringType.Latin1)
         );
 
@@ -323,8 +323,8 @@ import {Testers} from "../utilities/testers";
         channel2.peakVolume = BigInt(123);
 
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             ByteVector.fromString("foo", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),
             channel1.render(),

--- a/test-unit/id3v2/relativeVolumeFrameTests.ts
+++ b/test-unit/id3v2/relativeVolumeFrameTests.ts
@@ -277,8 +277,6 @@ import {Testers} from "../utilities/testers";
         return RelativeVolumeFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
-
     @test
     public fromIdentification() {
         // Act

--- a/test-unit/id3v2/synchronizedLyricsFrameTests.ts
+++ b/test-unit/id3v2/synchronizedLyricsFrameTests.ts
@@ -46,8 +46,6 @@ import {SynchronizedTextType, TimestampFormat} from "../../src/id3v2/utilTypes";
         return SynchronizedLyricsFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
-
     @test
     public fromInfo_withoutEncoding() {
         // Arrange

--- a/test-unit/id3v2/synchronizedLyricsFrameTests.ts
+++ b/test-unit/id3v2/synchronizedLyricsFrameTests.ts
@@ -99,8 +99,8 @@ import {SynchronizedTextType, TimestampFormat} from "../../src/id3v2/utilTypes";
         const header = new Id3v2FrameHeader(FrameIdentifiers.SYLT);
         header.frameSize = 5;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             0x00, 0x00, 0x00, 0x00, 0x00
         );
 
@@ -114,8 +114,8 @@ import {SynchronizedTextType, TimestampFormat} from "../../src/id3v2/utilTypes";
         const header = new Id3v2FrameHeader(FrameIdentifiers.SYLT);
         header.frameSize = 10;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x01, 0x02, 0x03, 0x04, 0x05
         );
@@ -130,8 +130,8 @@ import {SynchronizedTextType, TimestampFormat} from "../../src/id3v2/utilTypes";
         const header = new Id3v2FrameHeader(FrameIdentifiers.SYLT);
         header.frameSize = 16;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             StringType.UTF16BE,
             ByteVector.fromString("fux", StringType.Latin1),
             TimestampFormat.AbsoluteMilliseconds,
@@ -152,8 +152,8 @@ import {SynchronizedTextType, TimestampFormat} from "../../src/id3v2/utilTypes";
         const content1 = new SynchronizedText(123, "qux");
         const content2 = new SynchronizedText(456, "zux");
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             StringType.UTF16BE,
             ByteVector.fromString("fux", StringType.Latin1),
             TimestampFormat.AbsoluteMilliseconds,
@@ -185,8 +185,8 @@ import {SynchronizedTextType, TimestampFormat} from "../../src/id3v2/utilTypes";
         const header = new Id3v2FrameHeader(FrameIdentifiers.SYLT);
         header.frameSize = 14;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             StringType.UTF16BE,
             ByteVector.fromString("fux", StringType.Latin1),
             TimestampFormat.AbsoluteMilliseconds,
@@ -217,8 +217,8 @@ import {SynchronizedTextType, TimestampFormat} from "../../src/id3v2/utilTypes";
         header.frameSize = 26;
         const content1 = new SynchronizedText(123, "qux");
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             StringType.UTF16BE,
             ByteVector.fromString("fux", StringType.Latin1),
             TimestampFormat.AbsoluteMilliseconds,
@@ -251,8 +251,8 @@ import {SynchronizedTextType, TimestampFormat} from "../../src/id3v2/utilTypes";
         const content1 = new SynchronizedText(123, "qux");
         const content2 = new SynchronizedText(456, "zux");
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             StringType.UTF16BE,
             ByteVector.fromString("fux", StringType.Latin1),
             TimestampFormat.AbsoluteMilliseconds,

--- a/test-unit/id3v2/synchronizedLyricsFrameTests.ts
+++ b/test-unit/id3v2/synchronizedLyricsFrameTests.ts
@@ -46,9 +46,7 @@ import {SynchronizedTextType, TimestampFormat} from "../../src/id3v2/utilTypes";
         return SynchronizedLyricsFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame {
-        return SynchronizedLyricsFrame.fromRawData;
-    }
+    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
 
     @test
     public fromInfo_withoutEncoding() {
@@ -96,41 +94,44 @@ import {SynchronizedTextType, TimestampFormat} from "../../src/id3v2/utilTypes";
     }
 
     @test
-    public fromRawData_notEnoughBytes() {
+    public fromOffsetRawData_notEnoughBytes() {
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.SYLT);
         header.frameSize = 5;
         const data = ByteVector.concatenate(
             header.render(4),
+            0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00
         );
 
         // Act / Assert
-        assert.throws(() => { SynchronizedLyricsFrame.fromRawData(data, 4); });
+        assert.throws(() => { SynchronizedLyricsFrame.fromOffsetRawData(data, 2, header, 4); });
     }
 
     @test
-    public fromRawData_missingDelimiter() {
+    public fromOffsetRawData_missingDelimiter() {
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.SYLT);
         header.frameSize = 10;
         const data = ByteVector.concatenate(
             header.render(4),
+            0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x01, 0x02, 0x03, 0x04, 0x05
         );
 
         // Act / Assert
-        assert.throws(() => { SynchronizedLyricsFrame.fromRawData(data, 4); });
+        assert.throws(() => { SynchronizedLyricsFrame.fromOffsetRawData(data, 2, header, 4); });
     }
 
     @test
-    public fromRawData_noDelimiterForSynchronizedText() {
+    public fromOffsetRawData_noDelimiterForSynchronizedText() {
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.SYLT);
         header.frameSize = 16;
         const data = ByteVector.concatenate(
             header.render(4),
+            0x00, 0x00,
             StringType.UTF16BE,
             ByteVector.fromString("fux", StringType.Latin1),
             TimestampFormat.AbsoluteMilliseconds,
@@ -140,11 +141,11 @@ import {SynchronizedTextType, TimestampFormat} from "../../src/id3v2/utilTypes";
         );
 
         // Act / Assert
-        assert.throws(() => { SynchronizedLyricsFrame.fromRawData(data, 4); });
+        assert.throws(() => { SynchronizedLyricsFrame.fromOffsetRawData(data, 2, header, 4); });
     }
 
     @test
-    public fromRawData_incompleteSynchronizedText() {
+    public fromOffsetRawData_incompleteSynchronizedText() {
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.SYLT);
         header.frameSize = 34;
@@ -152,6 +153,7 @@ import {SynchronizedTextType, TimestampFormat} from "../../src/id3v2/utilTypes";
         const content2 = new SynchronizedText(456, "zux");
         const data = ByteVector.concatenate(
             header.render(4),
+            0x00, 0x00,
             StringType.UTF16BE,
             ByteVector.fromString("fux", StringType.Latin1),
             TimestampFormat.AbsoluteMilliseconds,
@@ -163,7 +165,7 @@ import {SynchronizedTextType, TimestampFormat} from "../../src/id3v2/utilTypes";
         );
 
         // Act
-        const frame = SynchronizedLyricsFrame.fromRawData(data, 4);
+        const frame = SynchronizedLyricsFrame.fromOffsetRawData(data, 2, header, 4);
 
         // Assert
         Id3v2_SynchronizedLyricsFrame_ConstructorTests.assertFrame(
@@ -178,12 +180,13 @@ import {SynchronizedTextType, TimestampFormat} from "../../src/id3v2/utilTypes";
     }
 
     @test
-    public fromRawData_noData() {
+    public fromOffsetRawData_noData() {
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.SYLT);
         header.frameSize = 14;
         const data = ByteVector.concatenate(
             header.render(4),
+            0x00, 0x00,
             StringType.UTF16BE,
             ByteVector.fromString("fux", StringType.Latin1),
             TimestampFormat.AbsoluteMilliseconds,
@@ -193,7 +196,7 @@ import {SynchronizedTextType, TimestampFormat} from "../../src/id3v2/utilTypes";
         );
 
         // Act
-        const frame = SynchronizedLyricsFrame.fromRawData(data, 4);
+        const frame = SynchronizedLyricsFrame.fromOffsetRawData(data, 2, header, 4);
 
         // Assert
         Id3v2_SynchronizedLyricsFrame_ConstructorTests.assertFrame(
@@ -208,13 +211,14 @@ import {SynchronizedTextType, TimestampFormat} from "../../src/id3v2/utilTypes";
     }
 
     @test
-    public fromRawData_singleData() {
+    public fromOffsetRawData_singleData() {
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.SYLT);
         header.frameSize = 26;
         const content1 = new SynchronizedText(123, "qux");
         const data = ByteVector.concatenate(
             header.render(4),
+            0x00, 0x00,
             StringType.UTF16BE,
             ByteVector.fromString("fux", StringType.Latin1),
             TimestampFormat.AbsoluteMilliseconds,
@@ -225,7 +229,7 @@ import {SynchronizedTextType, TimestampFormat} from "../../src/id3v2/utilTypes";
         );
 
         // Act
-        const frame = SynchronizedLyricsFrame.fromRawData(data, 4);
+        const frame = SynchronizedLyricsFrame.fromOffsetRawData(data, 2, header, 4);
 
         // Assert
         Id3v2_SynchronizedLyricsFrame_ConstructorTests.assertFrame(
@@ -234,40 +238,6 @@ import {SynchronizedTextType, TimestampFormat} from "../../src/id3v2/utilTypes";
             TimestampFormat.AbsoluteMilliseconds,
             "fux",
             [content1],
-            StringType.UTF16BE,
-            SynchronizedTextType.Trivia
-        );
-    }
-
-    @test
-    public fromRawData_multipleData() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.SYLT);
-        header.frameSize = 38;
-        const content1 = new SynchronizedText(123, "qux");
-        const content2 = new SynchronizedText(456, "zux");
-        const data = ByteVector.concatenate(
-            header.render(4),
-            StringType.UTF16BE,
-            ByteVector.fromString("fux", StringType.Latin1),
-            TimestampFormat.AbsoluteMilliseconds,
-            SynchronizedTextType.Trivia,
-            ByteVector.fromString("bux", StringType.UTF16BE),
-            ByteVector.getTextDelimiter(StringType.UTF16BE),
-            content1.render(StringType.UTF16BE),
-            content2.render(StringType.UTF16BE)
-        );
-
-        // Act
-        const frame = SynchronizedLyricsFrame.fromRawData(data, 4);
-
-        // Assert
-        Id3v2_SynchronizedLyricsFrame_ConstructorTests.assertFrame(
-            frame,
-            "bux",
-            TimestampFormat.AbsoluteMilliseconds,
-            "fux",
-            [content1, content2],
             StringType.UTF16BE,
             SynchronizedTextType.Trivia
         );
@@ -640,7 +610,7 @@ import {SynchronizedTextType, TimestampFormat} from "../../src/id3v2/utilTypes";
             content1.render(StringType.UTF16BE),
             content2.render(StringType.UTF16BE)
         );
-        const frame = SynchronizedLyricsFrame.fromRawData(data, 4);
+        const frame = SynchronizedLyricsFrame.fromOffsetRawData(data, 0, header, 4);
 
         // Act
         const output = frame.render(4);
@@ -649,4 +619,3 @@ import {SynchronizedTextType, TimestampFormat} from "../../src/id3v2/utilTypes";
         Testers.bvEqual(output, data);
     }
 }
-

--- a/test-unit/id3v2/tconFrameTests.ts
+++ b/test-unit/id3v2/tconFrameTests.ts
@@ -246,7 +246,7 @@ class Id3v2_TconFrameTests {
         const header = new Id3v2FrameHeader(FrameIdentifiers.TCON, Id3v2FrameFlags.None, bodyBytes.length);
 
         const frameBytes = ByteVector.concatenate(header.render(tagVersion), bodyBytes);
-        const frame = TextInformationFrame.fromRawData(frameBytes, tagVersion);
+        const frame = TextInformationFrame.fromOffsetRawData(frameBytes, 0, header, tagVersion);
 
         // Act
         const values = frame.text;

--- a/test-unit/id3v2/termsOfUseFrameTests.ts
+++ b/test-unit/id3v2/termsOfUseFrameTests.ts
@@ -236,7 +236,7 @@ import {Testers} from "../utilities/testers";
     @test
     public render() {
         // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.SYLT);
+        const header = new Id3v2FrameHeader(FrameIdentifiers.USER);
         header.frameSize = 10;
         const data = ByteVector.concatenate(
             header.render(4),

--- a/test-unit/id3v2/termsOfUseFrameTests.ts
+++ b/test-unit/id3v2/termsOfUseFrameTests.ts
@@ -16,9 +16,7 @@ import {Testers} from "../utilities/testers";
         return TermsOfUseFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame {
-        return TermsOfUseFrame.fromRawData;
-    }
+    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
 
     @test
     public fromFields_withoutTextEncoding() {
@@ -68,39 +66,6 @@ import {Testers} from "../utilities/testers";
 
         // Act
         const output = TermsOfUseFrame.fromOffsetRawData(data, 2, header, 4);
-
-        // Assert
-        Id3v2_TermsOfUseFrame_ConstructorTests.assertFrame(output, "fux", "buxqux", StringType.Latin1);
-    }
-
-    @test
-    public fromRawData_notEnoughBytes() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.USER);
-        header.frameSize = 2;
-        const data = ByteVector.concatenate(
-            header.render(4),
-            0x01, 0x02
-        );
-
-        // Act / Assert
-        assert.throws(() => { TermsOfUseFrame.fromRawData(data, 4); });
-    }
-
-    @test
-    public fromRawData_enoughData() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.USER);
-        header.frameSize = 10;
-        const data = ByteVector.concatenate(
-            header.render(4),
-            StringType.Latin1,
-            ByteVector.fromString("fux", StringType.Latin1),
-            ByteVector.fromString("buxqux", StringType.Latin1)
-        );
-
-        // Act
-        const output = TermsOfUseFrame.fromRawData(data, 4);
 
         // Assert
         Id3v2_TermsOfUseFrame_ConstructorTests.assertFrame(output, "fux", "buxqux", StringType.Latin1);
@@ -281,7 +246,7 @@ import {Testers} from "../utilities/testers";
             ByteVector.fromString("fux", StringType.Latin1),
             ByteVector.fromString("buxqux", StringType.Latin1)
         );
-        const frame = TermsOfUseFrame.fromRawData(data, 4);
+        const frame = TermsOfUseFrame.fromOffsetRawData(data, 0, header, 4);
 
         // Act
         const output = frame.render(4);

--- a/test-unit/id3v2/termsOfUseFrameTests.ts
+++ b/test-unit/id3v2/termsOfUseFrameTests.ts
@@ -16,8 +16,6 @@ import {Testers} from "../utilities/testers";
         return TermsOfUseFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
-
     @test
     public fromFields_withoutTextEncoding() {
         // Act

--- a/test-unit/id3v2/termsOfUseFrameTests.ts
+++ b/test-unit/id3v2/termsOfUseFrameTests.ts
@@ -42,8 +42,8 @@ import {Testers} from "../utilities/testers";
         const header = new Id3v2FrameHeader(FrameIdentifiers.USER);
         header.frameSize = 2;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00, // Offset data
+            header.render(4),
             0x00, 0x00
         );
 
@@ -57,8 +57,8 @@ import {Testers} from "../utilities/testers";
         const header = new Id3v2FrameHeader(FrameIdentifiers.USER);
         header.frameSize = 10;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x01, 0x00, // Offset data
+            header.render(4),
             StringType.Latin1,
             ByteVector.fromString("fux", StringType.Latin1),
             ByteVector.fromString("buxqux", StringType.Latin1)

--- a/test-unit/id3v2/textInformationFrameTests.ts
+++ b/test-unit/id3v2/textInformationFrameTests.ts
@@ -24,7 +24,7 @@ const getTestFrame = (): TextInformationFrame => {
         ByteVector.fromString("bar", StringType.Latin1),
     );
 
-    return TextInformationFrame.fromRawData(data, 4);
+    return TextInformationFrame.fromOffsetRawData(data, 0, header, 4);
 }
 
 @suite class Id3v2_TextInformationFrame_ConstructorTests extends FrameConstructorTests {
@@ -32,9 +32,7 @@ const getTestFrame = (): TextInformationFrame => {
         return TextInformationFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame {
-        return TextInformationFrame.fromRawData;
-    }
+    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
 
     @test
     public fromIdentifier_noEncoding_returnsFrameWithDefaultEncoding() {
@@ -62,73 +60,50 @@ const getTestFrame = (): TextInformationFrame => {
     }
 
     @test
-    public fromRawData_emptyFrameByLength_returnsEmptyFrame() {
+    public fromOffsetRawData_emptyFrameByLength_returnsEmptyFrame() {
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.TCOP);
         header.frameSize = 1;
         const data = ByteVector.concatenate(
             header.render(3),
+            0x00, 0x00,
             StringType.Latin1
         );
 
         // Act
-        const frame = TextInformationFrame.fromRawData(data, 3);
+        const frame = TextInformationFrame.fromOffsetRawData(data, 2, header, 3);
 
         // Assert
         Id3v2_TextInformationFrame_ConstructorTests.assertFrame(frame, FrameIdentifiers.TCOP, []);
     }
 
     @test
-    public fromRawData_emptyFrameByContents_returnsEmptyFrame() {
+    public fromOffsetRawData_emptyFrameByContents_returnsEmptyFrame() {
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.TCOP);
         header.frameSize = 3;
         const data = ByteVector.concatenate(
             header.render(3),
+            0x00, 0x00,
             StringType.Latin1,
             0x0, 0x0
         );
 
         // Act
-        const frame = TextInformationFrame.fromRawData(data, 3);
+        const frame = TextInformationFrame.fromOffsetRawData(data, 2, header, 3);
 
         // Assert
         Id3v2_TextInformationFrame_ConstructorTests.assertFrame(frame, FrameIdentifiers.TCOP, []);
     }
 
     @test
-    public fromRawData_v4NotTxxx_returnsFrameSplitByDelimiter() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.TCOP);
-        header.frameSize = 17;
-        const data = ByteVector.concatenate(
-            header.render(4),
-            StringType.UTF16BE,
-            ByteVector.fromString("fux", StringType.UTF16BE),
-            ByteVector.getTextDelimiter(StringType.UTF16BE),
-            ByteVector.fromString("bux", StringType.UTF16BE),
-            0x0, 0x0,   // Extra nulls to trigger null stripping logic
-        );
-
-        // Act
-        const frame = TextInformationFrame.fromRawData(data, 4);
-
-        // Assert
-        Id3v2_TextInformationFrame_ConstructorTests.assertFrame(
-            frame,
-            FrameIdentifiers.TCOP,
-            ["fux", "bux"],
-            StringType.UTF16BE
-        );
-    }
-
-    @test
-    public fromRawData_txxx_returnsFrameSplitByDelimiter() {
+    public fromOffsetRawData_txxx_returnsFrameSplitByDelimiter() {
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.TXXX);
         header.frameSize = 17;
         const data = ByteVector.concatenate(
             header.render(4),
+            0x00, 0x00,
             StringType.UTF16BE,
             ByteVector.fromString("fux", StringType.UTF16BE),
             ByteVector.getTextDelimiter(StringType.UTF16BE),
@@ -137,7 +112,7 @@ const getTestFrame = (): TextInformationFrame => {
         );
 
         // Act
-        const frame = TextInformationFrame.fromRawData(data, 4);
+        const frame = TextInformationFrame.fromOffsetRawData(data, 2, header, 4);
 
         // Assert
         Id3v2_TextInformationFrame_ConstructorTests.assertFrame(
@@ -149,30 +124,32 @@ const getTestFrame = (): TextInformationFrame => {
     }
 
     @test
-    public fromRawData_v3SplitType_returnsFrameSplitBySlash() {
+    public fromOffsetRawData_v3SplitType_returnsFrameSplitBySlash() {
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.TCOM);
         header.frameSize = 8;
         const data = ByteVector.concatenate(
             header.render(3),
+            0x00, 0x00,
             StringType.Latin1,
             ByteVector.fromString("fux/bux", StringType.Latin1)
         );
 
         // Act
-        const frame = TextInformationFrame.fromRawData(data, 3);
+        const frame = TextInformationFrame.fromOffsetRawData(data, 2, header, 3);
 
         // Assert
         Id3v2_TextInformationFrame_ConstructorTests.assertFrame(frame, FrameIdentifiers.TCOM, ["fux", "bux"]);
     }
 
     @test
-    public fromRawData_v4Tcon_returnsListOfStrings() {
+    public fromOffsetRawData_v4Tcon_returnsListOfStrings() {
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.TCON);
         header.frameSize = 37;
         const data = ByteVector.concatenate(
             header.render(4),
+            0x00, 0x00,
             StringType.UTF16BE,
             ByteVector.fromString("32", StringType.UTF16BE),
             ByteVector.getTextDelimiter(StringType.UTF16BE),
@@ -182,7 +159,7 @@ const getTestFrame = (): TextInformationFrame => {
         );
 
         // Act
-        const frame = TextInformationFrame.fromRawData(data, 4);
+        const frame = TextInformationFrame.fromOffsetRawData(data, 2, header, 4);
 
         // Assert
         Id3v2_TextInformationFrame_ConstructorTests.assertFrame(
@@ -378,7 +355,7 @@ const getTestFrame = (): TextInformationFrame => {
             ByteVector.getTextDelimiter(StringType.Latin1),
             ByteVector.fromString("bux", StringType.Latin1),
         );
-        const frame = TextInformationFrame.fromRawData(data, 4);
+        const frame = TextInformationFrame.fromOffsetRawData(data, 0, header, 4);
 
         // Act
         const output = frame.render(4);
@@ -402,7 +379,7 @@ const getTestFrame = (): TextInformationFrame => {
             ByteVector.getTextDelimiter(StringType.UTF16BE),
             ByteVector.fromString("bux", StringType.UTF16BE),
         );
-        const frame = TextInformationFrame.fromRawData(data, 4);
+        const frame = TextInformationFrame.fromOffsetRawData(data, 0, header, 4);
         const _ = frame.text; // Force a read
 
         // Act
@@ -422,7 +399,7 @@ const getTestFrame = (): TextInformationFrame => {
             header.render(3),
             StringType.UTF8
         );
-        const frame = TextInformationFrame.fromRawData(data, 3);
+        const frame = TextInformationFrame.fromOffsetRawData(data, 0, header, 3);
         const _ = frame.text; // Force a read
 
         // Act
@@ -452,7 +429,7 @@ const getTestFrame = (): TextInformationFrame => {
             StringType.UTF16BE,
             ByteVector.fromString("fux", StringType.UTF16BE)
         );
-        const frame = TextInformationFrame.fromRawData(data, 3);
+        const frame = TextInformationFrame.fromOffsetRawData(data, 0, header, 3);
         const _ = frame.text; // Force a read
 
         // Act
@@ -483,7 +460,7 @@ const getTestFrame = (): TextInformationFrame => {
             StringType.UTF16BE,
             ByteVector.fromString("fux/bux", StringType.UTF16BE)
         );
-        const frame = TextInformationFrame.fromRawData(data, 3);
+        const frame = TextInformationFrame.fromOffsetRawData(data, 0, header, 3);
         const _ = frame.text; // Force a read
 
         // Act
@@ -504,7 +481,7 @@ const getTestFrame = (): TextInformationFrame => {
             StringType.UTF16BE,
             ByteVector.fromString("fux", StringType.UTF16BE)
         );
-        const frame = TextInformationFrame.fromRawData(data, 3);
+        const frame = TextInformationFrame.fromOffsetRawData(data, 0, header, 3);
         const _ = frame.text; // Force a read
 
         // Act
@@ -515,4 +492,3 @@ const getTestFrame = (): TextInformationFrame => {
         Testers.bvEqual(output, data);
     }
 }
-

--- a/test-unit/id3v2/textInformationFrameTests.ts
+++ b/test-unit/id3v2/textInformationFrameTests.ts
@@ -65,8 +65,8 @@ const getTestFrame = (): TextInformationFrame => {
         const header = new Id3v2FrameHeader(FrameIdentifiers.TCOP);
         header.frameSize = 1;
         const data = ByteVector.concatenate(
-            header.render(3),
             0x00, 0x00,
+            header.render(3),
             StringType.Latin1
         );
 
@@ -83,8 +83,8 @@ const getTestFrame = (): TextInformationFrame => {
         const header = new Id3v2FrameHeader(FrameIdentifiers.TCOP);
         header.frameSize = 3;
         const data = ByteVector.concatenate(
-            header.render(3),
             0x00, 0x00,
+            header.render(3),
             StringType.Latin1,
             0x0, 0x0
         );
@@ -102,8 +102,8 @@ const getTestFrame = (): TextInformationFrame => {
         const header = new Id3v2FrameHeader(FrameIdentifiers.TXXX);
         header.frameSize = 17;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             StringType.UTF16BE,
             ByteVector.fromString("fux", StringType.UTF16BE),
             ByteVector.getTextDelimiter(StringType.UTF16BE),
@@ -129,8 +129,8 @@ const getTestFrame = (): TextInformationFrame => {
         const header = new Id3v2FrameHeader(FrameIdentifiers.TCOM);
         header.frameSize = 8;
         const data = ByteVector.concatenate(
-            header.render(3),
             0x00, 0x00,
+            header.render(3),
             StringType.Latin1,
             ByteVector.fromString("fux/bux", StringType.Latin1)
         );
@@ -148,8 +148,8 @@ const getTestFrame = (): TextInformationFrame => {
         const header = new Id3v2FrameHeader(FrameIdentifiers.TCON);
         header.frameSize = 37;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             StringType.UTF16BE,
             ByteVector.fromString("32", StringType.UTF16BE),
             ByteVector.getTextDelimiter(StringType.UTF16BE),
@@ -180,8 +180,8 @@ const getTestFrame = (): TextInformationFrame => {
         const header = new Id3v2FrameHeader(FrameIdentifiers.TCOP);
         header.frameSize = 19;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             StringType.UTF16BE,
             ByteVector.fromString("fux", StringType.UTF16BE),
             ByteVector.getTextDelimiter(StringType.UTF16BE),

--- a/test-unit/id3v2/textInformationFrameTests.ts
+++ b/test-unit/id3v2/textInformationFrameTests.ts
@@ -32,8 +32,6 @@ const getTestFrame = (): TextInformationFrame => {
         return TextInformationFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
-
     @test
     public fromIdentifier_noEncoding_returnsFrameWithDefaultEncoding() {
         // Act

--- a/test-unit/id3v2/uniqueFileIdentifierFrameTests.ts
+++ b/test-unit/id3v2/uniqueFileIdentifierFrameTests.ts
@@ -58,8 +58,8 @@ const testOwner = "https://github.com/benrr101/node-taglib-sharp";
         const header = new Id3v2FrameHeader(FrameIdentifiers.UFID);
         header.frameSize = 9;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x0, 0x0,
+            header.render(4),
             testIdentifier
         );
 
@@ -76,8 +76,8 @@ const testOwner = "https://github.com/benrr101/node-taglib-sharp";
         const header = new Id3v2FrameHeader(FrameIdentifiers.UFID);
         header.frameSize = 29;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x0, 0x0,
+            header.render(4),
             testIdentifier,
             ByteVector.getTextDelimiter(StringType.Latin1),
             testIdentifier,
@@ -99,8 +99,8 @@ const testOwner = "https://github.com/benrr101/node-taglib-sharp";
         const header = new Id3v2FrameHeader(FrameIdentifiers.UFID);
         header.frameSize = 55;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x0, 0x0,
+            header.render(4),
             ByteVector.fromString(testOwner, StringType.UTF8),
             ByteVector.getTextDelimiter(StringType.Latin1),
             testIdentifier

--- a/test-unit/id3v2/uniqueFileIdentifierFrameTests.ts
+++ b/test-unit/id3v2/uniqueFileIdentifierFrameTests.ts
@@ -19,8 +19,6 @@ const testOwner = "https://github.com/benrr101/node-taglib-sharp";
         return UniqueFileIdentifierFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
-
     @test
     public fromData_invalidOwner_throws() {
         // Arrange

--- a/test-unit/id3v2/uniqueFileIdentifierFrameTests.ts
+++ b/test-unit/id3v2/uniqueFileIdentifierFrameTests.ts
@@ -19,9 +19,7 @@ const testOwner = "https://github.com/benrr101/node-taglib-sharp";
         return UniqueFileIdentifierFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame {
-        return UniqueFileIdentifierFrame.fromRawData;
-    }
+    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
 
     @test
     public fromData_invalidOwner_throws() {
@@ -110,64 +108,6 @@ const testOwner = "https://github.com/benrr101/node-taglib-sharp";
 
         // Act
         const frame = UniqueFileIdentifierFrame.fromOffsetRawData(data, 2, header, 4);
-
-        // Assert
-        Id3v2_UniqueFileIdentifierFrame_ConstructorTests.assertFrame(frame, testOwner, testIdentifier);
-    }
-
-    @test
-    public fromRawData_tooFewFields_returnsEmptyFrame() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.UFID);
-        header.frameSize = 9;
-        const data = ByteVector.concatenate(
-            header.render(4),
-            testIdentifier
-        );
-
-        // Act
-        const frame = UniqueFileIdentifierFrame.fromRawData(data, 4);
-
-        // Assert
-        Id3v2_UniqueFileIdentifierFrame_ConstructorTests.assertFrame(frame, undefined, undefined);
-    }
-
-    @test
-    public fromRawData_tooManyFields_returnsEmptyFrame() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.UFID);
-        header.frameSize = 29;
-        const data = ByteVector.concatenate(
-            header.render(4),
-            testIdentifier,
-            ByteVector.getTextDelimiter(StringType.Latin1),
-            testIdentifier,
-            ByteVector.getTextDelimiter(StringType.Latin1),
-            testIdentifier,
-            ByteVector.getTextDelimiter(StringType.Latin1)
-        );
-
-        // Act
-        const frame = UniqueFileIdentifierFrame.fromRawData(data, 4);
-
-        // Assert
-        Id3v2_UniqueFileIdentifierFrame_ConstructorTests.assertFrame(frame, undefined, undefined);
-    }
-
-    @test
-    public fromRawData_validData_returnsFrame() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.UFID);
-        header.frameSize = 55;
-        const data = ByteVector.concatenate(
-            header.render(4),
-            ByteVector.fromString(testOwner, StringType.UTF8),
-            ByteVector.getTextDelimiter(StringType.Latin1),
-            testIdentifier
-        );
-
-        // Act
-        const frame = UniqueFileIdentifierFrame.fromRawData(data, 4);
 
         // Assert
         Id3v2_UniqueFileIdentifierFrame_ConstructorTests.assertFrame(frame, testOwner, testIdentifier);
@@ -286,7 +226,7 @@ const testOwner = "https://github.com/benrr101/node-taglib-sharp";
             ByteVector.getTextDelimiter(StringType.Latin1),
             testIdentifier
         );
-        const frame = UniqueFileIdentifierFrame.fromRawData(data, 4);
+        const frame = UniqueFileIdentifierFrame.fromOffsetRawData(data, 0, header, 4);
 
         // Act
         const result = frame.render(4);

--- a/test-unit/id3v2/unknownFrameTests.ts
+++ b/test-unit/id3v2/unknownFrameTests.ts
@@ -65,8 +65,8 @@ import {Testers} from "../utilities/testers";
         const header = new Id3v2FrameHeader(FrameIdentifiers.WXXX);
         header.frameSize = 11;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x0, 0x0,
+            header.render(4),
             ByteVector.fromString("foo bar baz", StringType.UTF8)
         );
 

--- a/test-unit/id3v2/unknownFrameTests.ts
+++ b/test-unit/id3v2/unknownFrameTests.ts
@@ -14,9 +14,7 @@ import {Testers} from "../utilities/testers";
         return UnknownFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame {
-        return UnknownFrame.fromRawData;
-    }
+    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
 
     @test
     public fromData_falsyType_throws() {
@@ -83,27 +81,6 @@ import {Testers} from "../utilities/testers";
         );
     }
 
-    @test
-    public fromRawData_validParams_returnsFrame() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.WXXX);
-        header.frameSize = 11;
-        const data = ByteVector.concatenate(
-            header.render(4),
-            ByteVector.fromString("foo bar baz", StringType.UTF8)
-        );
-
-        // Act
-        const frame = UnknownFrame.fromRawData(data, 4);
-
-        // Assert
-        Id3v2_UnknownFrame_ConstructorTests.assertFrame(
-            frame,
-            FrameIdentifiers.WXXX,
-            ByteVector.fromString("foo bar baz", StringType.UTF8)
-        );
-    }
-
     private static assertFrame(frame: UnknownFrame, fi: FrameIdentifier, d: ByteVector) {
         assert.ok(frame);
         assert.strictEqual(frame.frameClassType, FrameClassType.UnknownFrame);
@@ -127,7 +104,7 @@ import {Testers} from "../utilities/testers";
             header.render(4),
             ByteVector.fromString("foo bar baz", StringType.UTF8)
         );
-        const frame = UnknownFrame.fromRawData(data, 4);
+        const frame = UnknownFrame.fromOffsetRawData(data, 0, header, 4);
 
         // Act
         const result = <UnknownFrame> frame.clone();
@@ -149,7 +126,7 @@ import {Testers} from "../utilities/testers";
             header.render(4),
             ByteVector.fromString("foo bar baz", StringType.UTF8)
         );
-        const frame = UnknownFrame.fromRawData(data, 4);
+        const frame = UnknownFrame.fromOffsetRawData(data, 0, header, 4);
 
         // Act
         const result = frame.render(4);

--- a/test-unit/id3v2/unknownFrameTests.ts
+++ b/test-unit/id3v2/unknownFrameTests.ts
@@ -14,8 +14,6 @@ import {Testers} from "../utilities/testers";
         return UnknownFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
-
     @test
     public fromData_falsyType_throws() {
         // Act/Assert

--- a/test-unit/id3v2/unsynchronizedLyricsFrameTests.ts
+++ b/test-unit/id3v2/unsynchronizedLyricsFrameTests.ts
@@ -25,8 +25,10 @@ const getTestFrameData = (): ByteVector => {
 };
 
 const getTestUnsynchronizedLyricsFrame = (): UnsynchronizedLyricsFrame => {
+    const header = new Id3v2FrameHeader(FrameIdentifiers.USLT);
+    header.frameSize = 11;
     const frameData = getTestFrameData();
-    return UnsynchronizedLyricsFrame.fromRawData(frameData, 4);
+    return UnsynchronizedLyricsFrame.fromOffsetRawData(frameData, 0, header, 4);
 };
 
 @suite class Id3v2_UnsynchronizedLyricsFrame_ConstructorTests extends FrameConstructorTests {
@@ -34,9 +36,7 @@ const getTestUnsynchronizedLyricsFrame = (): UnsynchronizedLyricsFrame => {
         return UnsynchronizedLyricsFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame {
-        return UnsynchronizedLyricsFrame.fromRawData;
-    }
+    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
 
     @test
     public fromData() {
@@ -89,46 +89,6 @@ const getTestUnsynchronizedLyricsFrame = (): UnsynchronizedLyricsFrame => {
 
         // Act
         const frame = UnsynchronizedLyricsFrame.fromOffsetRawData(data, 2, header, 4);
-
-        // Assert
-        Id3v2_UnsynchronizedLyricsFrame_ConstructorTests.assertFrame(frame, "foo", "eng", "bar", StringType.Latin1);
-    }
-
-    @test
-    public fromRawData_missingDescription_returnsValidFrame() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.USLT);
-        header.frameSize = 7;
-        const data = ByteVector.concatenate(
-            header.render(4),                               // Header
-            StringType.Latin1,                                      // Encoding
-            ByteVector.fromString("eng", StringType.Latin1),    // Language
-            ByteVector.fromString("foo", StringType.UTF8)      // Content
-        );
-
-        // Act
-        const frame = UnsynchronizedLyricsFrame.fromRawData(data, 4);
-
-        // Assert
-        Id3v2_UnsynchronizedLyricsFrame_ConstructorTests.assertFrame(frame, "", "eng", "foo", StringType.Latin1);
-    }
-
-    @test
-    public fromRawData_withDescription_returnsValidFrame() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.USLT);
-        header.frameSize = 11;
-        const data = ByteVector.concatenate(
-            header.render(4),                               // Header
-            StringType.Latin1,                                      // Encoding
-            ByteVector.fromString("eng", StringType.Latin1),    // Language
-            ByteVector.fromString("foo", StringType.UTF8),     // Description
-            ByteVector.getTextDelimiter(StringType.Latin1),         // Delimiter
-            ByteVector.fromString("bar", StringType.UTF8)      // Content
-        );
-
-        // Act
-        const frame = UnsynchronizedLyricsFrame.fromRawData(data, 4);
 
         // Assert
         Id3v2_UnsynchronizedLyricsFrame_ConstructorTests.assertFrame(frame, "foo", "eng", "bar", StringType.Latin1);

--- a/test-unit/id3v2/unsynchronizedLyricsFrameTests.ts
+++ b/test-unit/id3v2/unsynchronizedLyricsFrameTests.ts
@@ -36,8 +36,6 @@ const getTestUnsynchronizedLyricsFrame = (): UnsynchronizedLyricsFrame => {
         return UnsynchronizedLyricsFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
-
     @test
     public fromData() {
         // Arrange

--- a/test-unit/id3v2/urlLinkFrameTests.ts
+++ b/test-unit/id3v2/urlLinkFrameTests.ts
@@ -25,8 +25,10 @@ const getTestFrameData = (): ByteVector => {
 };
 
 const getTestUrlLinkFrame = (): UrlLinkFrame => {
+    const header = new Id3v2FrameHeader(FrameIdentifiers.WXXX);
+    header.frameSize = 8;
     const frameData = getTestFrameData();
-    return UrlLinkFrame.fromRawData(frameData, 4);
+    return UrlLinkFrame.fromOffsetRawData(frameData, 0, header, 4);
 };
 
 @suite class Id3v2_UrlLinkFrame_ConstructorTests extends FrameConstructorTests {
@@ -34,9 +36,7 @@ const getTestUrlLinkFrame = (): UrlLinkFrame => {
         return UrlLinkFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame {
-        return UrlLinkFrame.fromRawData;
-    }
+    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
 
     @test
     public fromIdentity_falsyIdentity() {
@@ -88,50 +88,6 @@ const getTestUrlLinkFrame = (): UrlLinkFrame => {
 
         // Act
         const output = UrlLinkFrame.fromOffsetRawData(data, 2, header, 4);
-
-        // Assert
-        Id3v2_UrlLinkFrame_ConstructorTests.assertFrame(
-            output,
-            FrameIdentifiers.WXXX,
-            ["foo", "bar"],
-            StringType.Latin1
-        );
-    }
-
-    @test
-    public fromRawData_notUserFrame() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.WCOM);
-        header.frameSize = 8;
-        const data = ByteVector.concatenate(
-            header.render(4),
-            ByteVector.fromString("foobar", StringType.Latin1),    // - Data
-            0x00, 0x00                                             // - null bytes to test end byte
-                                                                   //   cleanup
-        );
-
-        // Act
-        const output = UrlLinkFrame.fromRawData(data, 4);
-
-        // Assert
-        Id3v2_UrlLinkFrame_ConstructorTests.assertFrame(output, FrameIdentifiers.WCOM, ["foobar"], StringType.Latin1);
-    }
-
-    @test
-    public fromRawData_userFrame() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.WXXX);
-        header.frameSize = 12;
-        const data = ByteVector.concatenate(
-            header.render(4),
-            StringType.UTF16BE,
-            ByteVector.fromString("foo", StringType.UTF16BE),
-            ByteVector.getTextDelimiter(StringType.UTF16BE),
-            ByteVector.fromString("bar", StringType.Latin1)
-        );
-
-        // Act
-        const output = UrlLinkFrame.fromRawData(data, 4);
 
         // Assert
         Id3v2_UrlLinkFrame_ConstructorTests.assertFrame(

--- a/test-unit/id3v2/urlLinkFrameTests.ts
+++ b/test-unit/id3v2/urlLinkFrameTests.ts
@@ -59,8 +59,8 @@ const getTestUrlLinkFrame = (): UrlLinkFrame => {
         const header = new Id3v2FrameHeader(FrameIdentifiers.WCOM);
         header.frameSize = TestConstants.syncedUint;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             ByteVector.fromString("foobar", StringType.Latin1),
             0x00, 0x00 // Some null bytes to trigger null cleanup
         );
@@ -78,8 +78,8 @@ const getTestUrlLinkFrame = (): UrlLinkFrame => {
         const header = new Id3v2FrameHeader(FrameIdentifiers.WXXX);
         header.frameSize = 12;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             StringType.UTF16BE,
             ByteVector.fromString("foo", StringType.UTF16BE),
             ByteVector.getTextDelimiter(StringType.UTF16BE),

--- a/test-unit/id3v2/urlLinkFrameTests.ts
+++ b/test-unit/id3v2/urlLinkFrameTests.ts
@@ -36,8 +36,6 @@ const getTestUrlLinkFrame = (): UrlLinkFrame => {
         return UrlLinkFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
-
     @test
     public fromIdentity_falsyIdentity() {
         // Act/Assert

--- a/test-unit/id3v2/userTextInformationFrameTests.ts
+++ b/test-unit/id3v2/userTextInformationFrameTests.ts
@@ -55,8 +55,8 @@ const getTestFrame = (): UserTextInformationFrame => {
         const header = new Id3v2FrameHeader(FrameIdentifiers.TXXX);
         header.frameSize = 8;
         const data = ByteVector.concatenate(
-            header.render(4),
             0x00, 0x00,
+            header.render(4),
             StringType.Latin1,
             ByteVector.fromString("foo", StringType.UTF8),
             ByteVector.getTextDelimiter(StringType.Latin1),

--- a/test-unit/id3v2/userTextInformationFrameTests.ts
+++ b/test-unit/id3v2/userTextInformationFrameTests.ts
@@ -21,7 +21,7 @@ const getTestFrame = (): UserTextInformationFrame => {
         ByteVector.fromString("bar", StringType.UTF8)
     );
 
-    return UserTextInformationFrame.fromRawData(data, 4);
+    return UserTextInformationFrame.fromOffsetRawData(data, 0, header, 4);
 }
 
 @suite class Id3v2_UserInformationFrame_ConstructorTests extends FrameConstructorTests {
@@ -29,9 +29,7 @@ const getTestFrame = (): UserTextInformationFrame => {
         return UserTextInformationFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame {
-        return UserTextInformationFrame.fromRawData;
-    }
+    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
 
     @test
     public fromDescription_noEncoding_returnsFrameWithDefaultEncoding() {
@@ -67,26 +65,6 @@ const getTestFrame = (): UserTextInformationFrame => {
 
         // Act
         const frame = UserTextInformationFrame.fromOffsetRawData(data, 2, header, 4);
-
-        // Assert
-        Id3v2_UserInformationFrame_ConstructorTests.assertFrame(frame, "foo", ["bar"], StringType.Latin1);
-    }
-
-    @test
-    public fromRawData_returnsFrame() {
-        // Assert
-        const header = new Id3v2FrameHeader(FrameIdentifiers.TXXX);
-        header.frameSize = 8;
-        const data = ByteVector.concatenate(
-            header.render(4),
-            StringType.Latin1,
-            ByteVector.fromString("foo", StringType.UTF8),
-            ByteVector.getTextDelimiter(StringType.Latin1),
-            ByteVector.fromString("bar", StringType.UTF8)
-        );
-
-        // Act
-        const frame = UserTextInformationFrame.fromRawData(data, 4);
 
         // Assert
         Id3v2_UserInformationFrame_ConstructorTests.assertFrame(frame, "foo", ["bar"], StringType.Latin1);

--- a/test-unit/id3v2/userTextInformationFrameTests.ts
+++ b/test-unit/id3v2/userTextInformationFrameTests.ts
@@ -29,8 +29,6 @@ const getTestFrame = (): UserTextInformationFrame => {
         return UserTextInformationFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
-
     @test
     public fromDescription_noEncoding_returnsFrameWithDefaultEncoding() {
         // Act

--- a/test-unit/id3v2/userUrlLinkFrameTests.ts
+++ b/test-unit/id3v2/userUrlLinkFrameTests.ts
@@ -23,8 +23,10 @@ const getTestFrameData = (): ByteVector => {
 };
 
 const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
+    const header = new Id3v2FrameHeader(FrameIdentifiers.WXXX);
+    header.frameSize = 12;
     const frameData = getTestFrameData();
-    return UserUrlLinkFrame.fromRawData(frameData, 4);
+    return UserUrlLinkFrame.fromOffsetRawData(frameData, 0, header, 4);
 };
 
 @suite class Id3v2_UserUrlLinkFrame_ConstructorTests extends FrameConstructorTests {
@@ -32,9 +34,7 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
         return UserUrlLinkFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame {
-        return UserUrlLinkFrame.fromRawData;
-    }
+    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
 
     @test
     public fromOffsetRawData_userFrame() {
@@ -63,39 +63,15 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
         assert.equal(output.textEncoding, StringType.Latin1);
     }
 
-    @test
-    public fromRawData_userFrame() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.WXXX);
-        header.frameSize = 8;
-        const data = ByteVector.concatenate(
-            header.render(4),
-            StringType.Latin1,
-            ByteVector.fromString("foo", StringType.Latin1),   // - String 1
-            ByteVector.getTextDelimiter(StringType.Latin1),         // - String separator
-            ByteVector.fromString("bar", StringType.Latin1)    // - String 2
-        );
-
-        // Act
-        const output = UserUrlLinkFrame.fromRawData(data, 4);
-
-        // Assert
-        assert.ok(output);
-        assert.equal(output.frameClassType, FrameClassType.UserUrlLinkFrame);
-        assert.strictEqual(output.frameId, FrameIdentifiers.WXXX);
-
-        assert.strictEqual(output.description, "foo");
-        assert.deepEqual(output.text, ["bar"]);
-        assert.equal(output.textEncoding, StringType.Latin1);
-    }
 }
 
 @suite class Id3v2_UserUrlLinkFrame_PropertyTests {
     @test
     public getDescription_emptyText_returnsUndefined() {
         // Arrange
-        const data = new Id3v2FrameHeader(FrameIdentifiers.WXXX).render(4);
-        const frame = UserUrlLinkFrame.fromRawData(data, 4);
+        const header = new Id3v2FrameHeader(FrameIdentifiers.WXXX);
+        const data = header.render(4);
+        const frame = UserUrlLinkFrame.fromOffsetRawData(data, 0, header, 4);
 
         // Act
         const result = frame.description;
@@ -152,7 +128,7 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
             header.render(4),
             0x00, 0x00,                 // - Frame flags
         );
-        const frame = UserUrlLinkFrame.fromRawData(data, 4);
+        const frame = UserUrlLinkFrame.fromOffsetRawData(data, 0, header, 4);
 
         // Act
         frame.description = "fux";

--- a/test-unit/id3v2/userUrlLinkFrameTests.ts
+++ b/test-unit/id3v2/userUrlLinkFrameTests.ts
@@ -34,8 +34,6 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
         return UserUrlLinkFrame.fromOffsetRawData;
     }
 
-    public get fromRawData(): (d: ByteVector, v: number) => Frame { return undefined; }
-
     @test
     public fromOffsetRawData_userFrame() {
         // Arrange


### PR DESCRIPTION
## Description
These methods aren't being used anywhere productively in the package. And I can't see why users/developers would want to construct a frame from raw data. There's still support for this via the offset raw data constructor, anyways. So, I decided to remove it.

## 🤖 
I did the first two classes by hand, then handed it over to the 🤖 to handle the rest for me. Looks like it did a decent job.