### PR TITLE
[ID3v2] Eager Load UrlLinkFrame and UserUrlLinkFrame

### DIFF
--- a/src/id3v2/frames/urlLinkFrame.ts
+++ b/src/id3v2/frames/urlLinkFrame.ts
@@ -272,7 +272,7 @@ export class UserUrlLinkFrame extends UrlLinkFrame {
             if (splitText.length > 1) {
                 // Data was probably encoded using old TagLib# behavior.
                 this._description = splitText[0];
-                this._text = splitText[0];
+                this._text = splitText[1];
             } else {
                 // Data has only one field, let's assume it only has a url.
                 this._description = undefined;

--- a/src/id3v2/frames/urlLinkFrame.ts
+++ b/src/id3v2/frames/urlLinkFrame.ts
@@ -1,3 +1,4 @@
+import Id3v2Settings from "../id3v2Settings";
 import {ByteVector, StringType} from "../../byteVector";
 import {Frame, FrameClassType} from "./frame";
 import {Id3v2FrameHeader} from "./frameHeader";
@@ -87,14 +88,12 @@ export class UrlLinkFrame extends Frame {
 
     /**
      * Gets the text contained in the current instance.
-     * Modifying the contents of the returned value will not modify the contents of the current
-     * instance. The value must be reassigned for the value to change.
      */
     public get text(): string { return this._text; }
     /**
      * Sets the text contained in the current instance.
      */
-    public set text(value: string) { this._text = value ?? ""; }
+    public set text(value: string) { this._text = value; }
 
     // #endregion
 
@@ -136,7 +135,11 @@ export class UrlLinkFrame extends Frame {
 
     /** @inheritDoc */
     protected renderFields(_version: number): ByteVector {
-        return ByteVector.fromString(this._text, StringType.Latin1);
+        if (!this._text) {
+            return ByteVector.empty();
+        }
+
+        return ByteVector.fromString(this.text, StringType.Latin1);
     }
 
     // #endregion
@@ -147,7 +150,7 @@ export class UrlLinkFrame extends Frame {
  */
 export class UserUrlLinkFrame extends UrlLinkFrame {
     private _description: string;
-    private _encoding: StringType = StringType.Latin1;
+    private _encoding: StringType = Id3v2Settings.defaultEncoding;
 
     // #region Constructors
 
@@ -156,14 +159,15 @@ export class UserUrlLinkFrame extends UrlLinkFrame {
     }
 
     /**
-     * Constructs and initializes a new instance using the provided description as the text
-     * of the frame.
-     * @param description Description to use as text of the frame.
+     * Constructs and initializes a new instance using the provided description and url to populate
+     * the fields of the frame.
+     * @param description Description to store in the frame
+     * @param url URL to store in the frame
      */
-    public static fromDescription(description: string): UserUrlLinkFrame {
+    public static fromFields(description: string, url: string): UserUrlLinkFrame {
         const frame = new UserUrlLinkFrame(new Id3v2FrameHeader(FrameIdentifiers.WXXX));
         frame._description = description;
-        frame._text = "";
+        frame._text = url;
         return frame;
     }
 
@@ -238,9 +242,8 @@ export class UserUrlLinkFrame extends UrlLinkFrame {
 
     /** @inheritDoc */
     public clone(): UserUrlLinkFrame {
-        const frame = UserUrlLinkFrame.fromDescription(this._description);
+        const frame = UserUrlLinkFrame.fromFields(this._description, this._text);
         frame._encoding = this._encoding;
-        frame._text = this._text;
         return frame;
     }
 
@@ -289,9 +292,9 @@ export class UserUrlLinkFrame extends UrlLinkFrame {
         const encoding = UrlLinkFrame.correctEncoding(this.textEncoding, version);
         return ByteVector.concatenate(
             UrlLinkFrame.correctEncoding(this._encoding, version),
-            ByteVector.fromString(this._description, encoding),
+            ByteVector.fromString(this._description ?? "", encoding),
             ByteVector.getTextDelimiter(this._encoding),
-            ByteVector.fromString(this._text, StringType.Latin1)
+            ByteVector.fromString(this._text ?? "", StringType.Latin1)
         );
     }
 

--- a/src/id3v2/frames/urlLinkFrame.ts
+++ b/src/id3v2/frames/urlLinkFrame.ts
@@ -34,25 +34,10 @@ import {Guards} from "../../utils";
 export class UrlLinkFrame extends Frame {
     // @TODO: Don't allow protected member variables
     /**
-     * Text encoding to use to store the text contents of the current instance.
-     * @protected
-     */
-    protected _encoding: StringType = StringType.Latin1;
-    /**
-     * Raw data contents in the current instance.
-     * @protected
-     */
-    protected _rawData: ByteVector;
-    /**
-     * ID3v2 version of the current instance.
-     * @protected
-     */
-    protected _rawVersion: number;
-    /**
      * Decoded text contained in the current instance.
      * @protected
      */
-    protected _textFields: string[] = [];
+    protected _text: string;
 
     // #region Constructors
 
@@ -105,31 +90,11 @@ export class UrlLinkFrame extends Frame {
      * Modifying the contents of the returned value will not modify the contents of the current
      * instance. The value must be reassigned for the value to change.
      */
-    public get text(): string[] {
-        this.parseRawData();
-        return this._textFields.slice(0);
-    }
+    public get text(): string { return this._text; }
     /**
      * Sets the text contained in the current instance.
      */
-    public set text(value: string[]) {
-        this._rawData = undefined;
-        this._textFields = value ? value.slice() : [];
-    }
-
-    /**
-     * Gets the text encoding to use when rendering the current instance.
-     */
-    public get textEncoding(): StringType {
-        this.parseRawData();
-        return this._encoding;
-    }
-    /**
-     * Sets the text encoding to use when rendering the current instance.
-     * NOTE: This value will be overwritten if {@link Id3v2Settings.forceDefaultEncoding} is `true`.
-     * @param value
-     */
-    public set textEncoding(value: StringType) { this._encoding = value; }
+    public set text(value: string) { this._text = value ?? ""; }
 
     // #endregion
 
@@ -151,101 +116,22 @@ export class UrlLinkFrame extends Frame {
     /** @inheritDoc */
     public clone(): UrlLinkFrame {
         const frame = UrlLinkFrame.fromIdentity(this.frameId);
-        frame._textFields = this._textFields.slice();
-        frame._rawData = this._rawData?.toByteVector();
-        frame._rawVersion = this._rawVersion;
+        frame._text = this._text;
         return frame;
     }
 
-    /**
-     * Generates a string representation of the URL link frame.
-     */
-    public toString(): string {
-        this.parseRawData();
-        return this.text.join("; ");
+    /** @inheritDoc */
+    protected parseFields(data: ByteVector, _version: number): void {
+        // Read the url from the data
+        let url = data.toString(StringType.Latin1);
+        url = url.replace(/[\s\0]+$/, "");
+
+        this._text = url;
     }
 
     /** @inheritDoc */
-    protected parseFields(data: ByteVector, version: number): void {
-        Guards.byte(version, "version");
-        this._rawData = data.toByteVector();
-        this._rawVersion = version;
-    }
-
-    /**
-     * Performs the actual parsing of the raw data.
-     * @remarks
-     *     Because of the high parsing cost and relatively low usage of the class,
-     *     {@link parseFields} only stores the field data, so it can be parsed on demand. Whenever
-     *     a property or method is called which requires the data, this method is called, and only
-     *     on the first call does it actually parse the data.
-     * @protected
-     */
-    protected parseRawData(): void {
-        if (!this._rawData) {
-            return;
-        }
-
-        const data = this._rawData;
-        this._rawData = undefined;
-
-        const fieldList = [];
-        let index = 0;
-        if (this.frameId === FrameIdentifiers.WXXX && data.length > 0) {
-            // Text Encoding    $xx
-            // Description      <text string according to encoding> $00 (00)
-            // URL              <text string>
-            const encoding = <StringType> data.get(index);
-            const delim = ByteVector.getTextDelimiter(encoding);
-            index++;
-
-            const delimIndex = data.offsetFind(delim, index, delim.length);
-            if (delimIndex >= 0) {
-                const descriptionLength = delimIndex - index;
-                const description = data.subarray(index, descriptionLength).toString(encoding);
-                fieldList.push(description);
-                index += descriptionLength + delim.length;
-            }
-        }
-
-        if (index < data.length) {
-
-            // Read the url from the data
-            let url = data.subarray(index).toString(StringType.Latin1);
-            url = url.replace(/[\s\0]+$/, "");
-
-            fieldList.push(url);
-        }
-        this._textFields = fieldList;
-    }
-
-    /** @inheritDoc */
-    protected renderFields(version: number): ByteVector {
-        // @TODO: Move WXXX rendering to WXXX class
-        if (this._rawData && this._rawVersion === version) {
-            return this._rawData;
-        }
-
-        const encoding = UrlLinkFrame.correctEncoding(this.textEncoding, version);
-        const isWxxx = this.frameId === FrameIdentifiers.WXXX;
-
-        let textFields = this._textFields;
-        if (version > 3 || isWxxx) {
-            if (isWxxx) {
-                if (textFields.length === 0) {
-                    textFields = [undefined, undefined];
-                } else if (textFields.length === 1) {
-                    textFields = [textFields[0], undefined];
-                }
-            }
-        }
-        // @TODO: is this correct formatting?
-        const text = textFields.join("/");
-
-        return ByteVector.concatenate(
-            isWxxx ? encoding : undefined,
-            ByteVector.fromString(text, StringType.Latin1)
-        );
+    protected renderFields(_version: number): ByteVector {
+        return ByteVector.fromString(this._text, StringType.Latin1);
     }
 
     // #endregion
@@ -255,6 +141,9 @@ export class UrlLinkFrame extends Frame {
  * Provides support for ID3v2 User URL Link frames (WXXX).
  */
 export class UserUrlLinkFrame extends UrlLinkFrame {
+    private _description: string;
+    private _encoding: StringType = StringType.Latin1;
+
     // #region Constructors
 
     private constructor(header: Id3v2FrameHeader) {
@@ -268,7 +157,8 @@ export class UserUrlLinkFrame extends UrlLinkFrame {
      */
     public static fromDescription(description: string): UserUrlLinkFrame {
         const frame = new UserUrlLinkFrame(new Id3v2FrameHeader(FrameIdentifiers.WXXX));
-        frame.text = [description];
+        frame._description = description;
+        frame._text = "";
         return frame;
     }
 
@@ -306,51 +196,23 @@ export class UserUrlLinkFrame extends UrlLinkFrame {
     /**
      * Gets the description stored in the current instance.
      */
-    public get description(): string {
-        const text = super.text;
-        return text.length > 0 ? text[0] : undefined;
-    }
+    public get description(): string { return this._text; }
     /**
      * Sets the description stored in the current instance.
      * There should only be one frame with a matching description per tag.
      */
-    public set description(value: string) {
-        const normalizedValue = value || undefined;
-
-        let text = super.text;
-        if (text.length > 0) {
-            text[0] = normalizedValue;
-        } else {
-            text = [normalizedValue];
-        }
-        super.text = text;
-    }
+    public set description(value: string) { this._description = value; }
 
     /**
-     * Gets the text contained in the current instance.
-     * NOTE: Modifying the contents of the returned value will not modify the contents of the
-     * current instance. The value must be reassigned for the value to change.
+     * Gets the text encoding to use when rendering the current instance.
      */
-    public get text(): string[] {
-        const text = super.text;
-        if (text.length < 2) { return []; }
-
-        const newText = new Array<string>(text.length - 1);
-        for (let i = 0; i < newText.length; i++) {
-            newText[i] = text[i + 1];
-        }
-        return newText;
-    }
+    public get textEncoding(): StringType { return this._encoding; }
     /**
-     * Sets the text contained in the current instance.
+     * Sets the text encoding to use when rendering the current instance.
+     * NOTE: This value will be overwritten if {@link Id3v2Settings.forceDefaultEncoding} is `true`.
+     * @param value
      */
-    public set text(value: string[]) {
-        const newValue = [this.description];
-        if (value) {
-            newValue.push(... value);
-        }
-        super.text = newValue;
-    }
+    public set textEncoding(value: StringType) { this._encoding = value; }
 
     // #endregion
 
@@ -371,17 +233,51 @@ export class UserUrlLinkFrame extends UrlLinkFrame {
 
     /** @inheritDoc */
     public clone(): UserUrlLinkFrame {
-        const frame = UserUrlLinkFrame.fromDescription(undefined);
+        const frame = UserUrlLinkFrame.fromDescription(this._description);
         frame._encoding = this._encoding;
-        frame._textFields = this._textFields.slice();
-        frame._rawData = this._rawData?.toByteVector();
-        frame._rawVersion = this._rawVersion;
+        frame._text = this._text;
         return frame;
     }
 
     /** @inheritDoc */
     public toString(): string {
         return `[${this.description}] ${super.toString()}`;
+    }
+
+    protected parseFields(data: ByteVector, _version: number): void {
+        if (data.length < 3) {
+            throw new Error("User URL link frame is smaller than minimum size.");
+        }
+
+        // Text Encoding    $xx
+        // Description      <text string according to encoding> $00 (00)
+        // URL              <text string>
+
+        const encoding = <StringType>data.get(0);
+
+        let splitText = data.toStrings(encoding, 2);
+        if (splitText.length < 2) {
+            // Ill-formed frame. Attempt to split by "/" like TagLib# encodes WXXX frames.
+            splitText = splitText[0].split("/");
+        }
+        if (splitText.length < 2) {
+            // Ill-formed frame. Assume description was omitted.
+            this._description = "";
+            this._text = splitText[0];
+        } else {
+            // Well-formed frame.
+            this._description = splitText[0];
+            this._text = splitText[1];
+        }
+    }
+
+    protected renderFields(version: number): ByteVector {
+        const encoding = UrlLinkFrame.correctEncoding(this.textEncoding, version);
+        return ByteVector.concatenate(
+            UrlLinkFrame.correctEncoding(this._encoding, version),
+            ByteVector.fromString(this._description, encoding),
+            ByteVector.fromString(this._text, StringType.Latin1)
+        );
     }
 
     // #endregion

--- a/src/id3v2/frames/urlLinkFrame.ts
+++ b/src/id3v2/frames/urlLinkFrame.ts
@@ -121,6 +121,11 @@ export class UrlLinkFrame extends Frame {
     }
 
     /** @inheritDoc */
+    public toString(): string {
+        return this.text;
+    }
+
+    /** @inheritDoc */
     protected parseFields(data: ByteVector, _version: number): void {
         // Read the url from the data
         let url = data.toString(StringType.Latin1);

--- a/src/id3v2/frames/urlLinkFrame.ts
+++ b/src/id3v2/frames/urlLinkFrame.ts
@@ -126,11 +126,7 @@ export class UrlLinkFrame extends Frame {
 
     /** @inheritDoc */
     protected parseFields(data: ByteVector, _version: number): void {
-        // Read the url from the data
-        let url = data.toString(StringType.Latin1);
-        url = url.replace(/[\s\0]+$/, "");
-
-        this._text = url;
+        this._text = data.toString(StringType.Latin1);
     }
 
     /** @inheritDoc */
@@ -293,7 +289,7 @@ export class UserUrlLinkFrame extends UrlLinkFrame {
         return ByteVector.concatenate(
             UrlLinkFrame.correctEncoding(this._encoding, version),
             ByteVector.fromString(this._description ?? "", encoding),
-            ByteVector.getTextDelimiter(this._encoding),
+            ByteVector.getTextDelimiter(encoding),
             ByteVector.fromString(this._text ?? "", StringType.Latin1)
         );
     }

--- a/src/id3v2/frames/urlLinkFrame.ts
+++ b/src/id3v2/frames/urlLinkFrame.ts
@@ -196,7 +196,7 @@ export class UserUrlLinkFrame extends UrlLinkFrame {
     /**
      * Gets the description stored in the current instance.
      */
-    public get description(): string { return this._text; }
+    public get description(): string { return this._description; }
     /**
      * Sets the description stored in the current instance.
      * There should only be one frame with a matching description per tag.
@@ -253,21 +253,30 @@ export class UserUrlLinkFrame extends UrlLinkFrame {
         // Description      <text string according to encoding> $00 (00)
         // URL              <text string>
 
-        const encoding = <StringType>data.get(0);
+        this._encoding = <StringType>data.get(0);
 
-        let splitText = data.toStrings(encoding, 2);
-        if (splitText.length < 2) {
-            // Ill-formed frame. Attempt to split by "/" like TagLib# encodes WXXX frames.
-            splitText = splitText[0].split("/");
-        }
-        if (splitText.length < 2) {
-            // Ill-formed frame. Assume description was omitted.
-            this._description = "";
-            this._text = splitText[0];
+        // Note: Although it would be nice to just split the data, because the first string is
+        //    encoded as per the encoding field and the second is always in Latin1, we cannot use
+        //    the toStrings method.
+        const textBytes = data.subarray(1);
+        const delimiter = ByteVector.getTextDelimiter(this._encoding);
+        const descriptionLength = textBytes.find(delimiter);
+        if (descriptionLength < 0) {
+            // Ill-formed frame.
+            const splitText = textBytes.toString(this._encoding).split("/");
+            if (splitText.length > 1) {
+                // Data was probably encoded using old TagLib# behavior.
+                this._description = splitText[0];
+                this._text = splitText[0];
+            } else {
+                // Data has only one field, let's assume it only has a url.
+                this._description = "";
+                this._text = splitText[0];
+            }
         } else {
-            // Well-formed frame.
-            this._description = splitText[0];
-            this._text = splitText[1];
+            // Well-formed frame
+            this._description = textBytes.subarray(0, descriptionLength).toString(this._encoding);
+            this._text = textBytes.subarray(descriptionLength + delimiter.length).toString(StringType.Latin1);
         }
     }
 

--- a/src/id3v2/frames/urlLinkFrame.ts
+++ b/src/id3v2/frames/urlLinkFrame.ts
@@ -270,7 +270,7 @@ export class UserUrlLinkFrame extends UrlLinkFrame {
                 this._text = splitText[0];
             } else {
                 // Data has only one field, let's assume it only has a url.
-                this._description = "";
+                this._description = undefined;
                 this._text = splitText[0];
             }
         } else {
@@ -285,6 +285,7 @@ export class UserUrlLinkFrame extends UrlLinkFrame {
         return ByteVector.concatenate(
             UrlLinkFrame.correctEncoding(this._encoding, version),
             ByteVector.fromString(this._description, encoding),
+            ByteVector.getTextDelimiter(this._encoding),
             ByteVector.fromString(this._text, StringType.Latin1)
         );
     }

--- a/src/id3v2/frames/urlLinkFrame.ts
+++ b/src/id3v2/frames/urlLinkFrame.ts
@@ -126,7 +126,9 @@ export class UrlLinkFrame extends Frame {
 
     /** @inheritDoc */
     protected parseFields(data: ByteVector, _version: number): void {
-        this._text = data.toString(StringType.Latin1);
+        // If data contains a string terminator, ignore everything after it.
+        const splitData = data.split(ByteVector.getTextDelimiter(StringType.Latin1));
+        this._text = splitData[0].toString(StringType.Latin1);
     }
 
     /** @inheritDoc */
@@ -262,12 +264,12 @@ export class UserUrlLinkFrame extends UrlLinkFrame {
         // Note: Although it would be nice to just split the data, because the first string is
         //    encoded as per the encoding field and the second is always in Latin1, we cannot use
         //    the toStrings method.
-        const textBytes = data.subarray(1);
+        const descriptionAndTextBytes = data.subarray(1);
         const delimiter = ByteVector.getTextDelimiter(this._encoding);
-        const descriptionLength = textBytes.find(delimiter);
+        const descriptionLength = descriptionAndTextBytes.find(delimiter);
         if (descriptionLength < 0) {
             // Ill-formed frame.
-            const splitText = textBytes.toString(this._encoding).split("/");
+            const splitText = descriptionAndTextBytes.toString(this._encoding).split("/");
             if (splitText.length > 1) {
                 // Data was probably encoded using old TagLib# behavior.
                 this._description = splitText[0];
@@ -278,13 +280,21 @@ export class UserUrlLinkFrame extends UrlLinkFrame {
                 this._text = splitText[0];
             }
         } else {
-            // Well-formed frame
-            this._description = textBytes.subarray(0, descriptionLength).toString(this._encoding);
-            this._text = textBytes.subarray(descriptionLength + delimiter.length).toString(StringType.Latin1);
+            // Well-formed frame (or >2 fields, the latter of which will be ignored)
+            const descriptionBytes = descriptionAndTextBytes.subarray(0, descriptionLength);
+            this._description = descriptionBytes.toString(this._encoding);
+
+            const textBytes = descriptionAndTextBytes.subarray(descriptionLength + delimiter.length);
+            const splitTextBytes = textBytes.split(ByteVector.getTextDelimiter(StringType.Latin1));
+            this._text = splitTextBytes[0].toString(StringType.Latin1);
         }
     }
 
     protected renderFields(version: number): ByteVector {
+        if (!this._description && !this._text) {
+            return ByteVector.empty();
+        }
+
         const encoding = UrlLinkFrame.correctEncoding(this.textEncoding, version);
         return ByteVector.concatenate(
             UrlLinkFrame.correctEncoding(this._encoding, version),

--- a/src/id3v2/id3v2Tag.ts
+++ b/src/id3v2/id3v2Tag.ts
@@ -1321,7 +1321,7 @@ export default class Id3v2Tag extends Tag {
      * @param text Text to set for the specified frame or `undefined`/`null`/`""` to remove all
      *     frames with that identifier.
      */
-    // @TODO: These methods doesn't cover all situations - what happens if there is >1 frame with the identity?
+    // @TODO: These methods don't cover all situations - what happens if there is >1 frame with the identity?
     //    what happens if the user specifies a TXXX frame?
     public setTextFrame(ident: FrameIdentifier, ...text: string[]): void {
         Guards.truthy(ident, "ident");
@@ -1347,17 +1347,20 @@ export default class Id3v2Tag extends Tag {
     }
 
     /**
-     * Sets the text for a specified text information frame.
+     * Sets the text for a specified URL frame.
      * @param ident Identifier of the frame to set the data for
-     * @param text Text to set for the specified frame or `undefined`/`null`/`""` to remove all
+     * @param text URL to set for the specified frame or `undefined`/`null`/`""` to remove all
      *     frames with that identifier.
      */
-    // @TODO: These methods doesn't cover all situations - what happens if there is >1 frame with the identity?
+    // @TODO: These methods don't cover all situations - what happens if there is >1 frame with the identity?
     //     what happens if the user specifies a WXXX frame?
     public setUrlFrame(ident: FrameIdentifier, text: string): void {
         Guards.truthy(ident, "ident");
         if (!ident.isUrlFrame) {
             throw new Error("Argument error: Identifier is not a URL frame.");
+        }
+        if (ident === FrameIdentifiers.WXXX) {
+            throw new Error("Argument error: WXXX frames cannot be set using this method.");
         }
 
         if (!text) {

--- a/src/id3v2/id3v2Tag.ts
+++ b/src/id3v2/id3v2Tag.ts
@@ -1328,6 +1328,9 @@ export default class Id3v2Tag extends Tag {
         if (!ident.isTextFrame) {
             throw new Error("Argument error: Identifier is not a text frame.");
         }
+        if (ident === FrameIdentifiers.TXXX) {
+            throw new Error("Argument error: TXXX frames cannot be set using this method.");
+        }
 
         // Check if all the elements provided are empty. If they are, remove the frame.
         if (!text.some(t => !!t)) {

--- a/src/id3v2/id3v2Tag.ts
+++ b/src/id3v2/id3v2Tag.ts
@@ -1321,46 +1321,58 @@ export default class Id3v2Tag extends Tag {
      * @param text Text to set for the specified frame or `undefined`/`null`/`""` to remove all
      *     frames with that identifier.
      */
+    // @TODO: These methods doesn't cover all situations - what happens if there is >1 frame with the identity?
+    //    what happens if the user specifies a TXXX frame?
     public setTextFrame(ident: FrameIdentifier, ...text: string[]): void {
         Guards.truthy(ident, "ident");
-
-        // Check if all the elements provided are empty. If they are, remove the frame.
-        let empty = true;
-
-        if (text) {
-            for (let i = 0; empty && i < text.length; i++) {
-                if (text[i]) {
-                    empty = false;
-                }
-            }
+        if (!ident.isTextFrame) {
+            throw new Error("Argument error: Identifier is not a text frame.");
         }
 
-        if (empty) {
+        // Check if all the elements provided are empty. If they are, remove the frame.
+        if (!text.some(t => !!t)) {
             this.removeFrames(ident);
             return;
         }
 
-        if (ident.isUrlFrame) {
-            const frames = this.getFramesByClassType<UrlLinkFrame>(FrameClassType.UrlLinkFrame);
-            let urlFrame = UrlLinkFrame.findUrlLinkFrame(frames, ident);
-            if (!urlFrame) {
-                urlFrame = UrlLinkFrame.fromIdentity(ident);
-                this.addFrame(urlFrame);
-            }
-
-            urlFrame.text = text;
-            urlFrame.textEncoding = Id3v2Settings.defaultEncoding;
-        } else {
-            const frames = this.getFramesByClassType<TextInformationFrame>(FrameClassType.TextInformationFrame);
-            let frame = TextInformationFrame.findTextInformationFrame(frames, ident);
-            if (!frame) {
-                frame = TextInformationFrame.fromIdentifier(ident);
-                this.addFrame(frame);
-            }
-
-            frame.text = text;
-            frame.textEncoding = Id3v2Settings.defaultEncoding;
+        const frames = this.getFramesByClassType<TextInformationFrame>(FrameClassType.TextInformationFrame);
+        let frame = TextInformationFrame.findTextInformationFrame(frames, ident);
+        if (!frame) {
+            frame = TextInformationFrame.fromIdentifier(ident);
+            this.addFrame(frame);
         }
+
+        frame.text = text;
+        frame.textEncoding = Id3v2Settings.defaultEncoding;
+    }
+
+    /**
+     * Sets the text for a specified text information frame.
+     * @param ident Identifier of the frame to set the data for
+     * @param text Text to set for the specified frame or `undefined`/`null`/`""` to remove all
+     *     frames with that identifier.
+     */
+    // @TODO: These methods doesn't cover all situations - what happens if there is >1 frame with the identity?
+    //     what happens if the user specifies a WXXX frame?
+    public setUrlFrame(ident: FrameIdentifier, text: string): void {
+        Guards.truthy(ident, "ident");
+        if (!ident.isUrlFrame) {
+            throw new Error("Argument error: Identifier is not a URL frame.");
+        }
+
+        if (!text) {
+            this.removeFrames(ident);
+            return;
+        }
+
+        const frames = this.getFramesByClassType<UrlLinkFrame>(FrameClassType.UrlLinkFrame);
+        let urlFrame = UrlLinkFrame.findUrlLinkFrame(frames, ident);
+        if (!urlFrame) {
+            urlFrame = UrlLinkFrame.fromIdentity(ident);
+            this.addFrame(urlFrame);
+        }
+
+        urlFrame.text = text;
     }
 
     // #endregion

--- a/test-unit/id3v2/frameFactoryTests.ts
+++ b/test-unit/id3v2/frameFactoryTests.ts
@@ -306,7 +306,7 @@ import {SynchronizedTextType, TimestampFormat} from "../../src/id3v2/utilTypes";
     public createFrame_fromData_urlFrame() {
         // Arrange
         const frame = UrlLinkFrame.fromIdentity(FrameIdentifiers.WCOM);
-        frame.text = ["foo"];
+        frame.text = "foo";
         const data = frame.render(4);
         // Act
         const output = Id3v2FrameFactory.createFrame(data, undefined, 0, 4, false);

--- a/test-unit/id3v2/frameFactoryTests.ts
+++ b/test-unit/id3v2/frameFactoryTests.ts
@@ -293,7 +293,7 @@ import {SynchronizedTextType, TimestampFormat} from "../../src/id3v2/utilTypes";
     @test
     public createFrame_fromData_wxxx() {
         // Arrange
-        const data = UserUrlLinkFrame.fromDescription("foo").render(4);
+        const data = UserUrlLinkFrame.fromFields("foo", "bar").render(4);
 
         // Act
         const output = Id3v2FrameFactory.createFrame(data, undefined, 0, 4, false);

--- a/test-unit/id3v2/id3v2TagTests.ts
+++ b/test-unit/id3v2/id3v2TagTests.ts
@@ -25,7 +25,6 @@ import {Testers} from "../utilities/testers";
 import {TextInformationFrame, UserTextInformationFrame} from "../../src/id3v2/frames/textInformationFrame";
 import {UrlLinkFrame} from "../../src/id3v2/frames/urlLinkFrame";
 import PrivateFrame from "../../src/id3v2/frames/privateFrame";
-import {Id3v2FrameIdentifier, Id3v2FrameIdentifiers, Id3v2UrlLinkFrame} from "../../src";
 
 const getTestTagHeader = (version: number, flags: Id3v2TagHeaderFlags, tagSize: number): ByteVector => {
     return ByteVector.concatenate(
@@ -2157,7 +2156,7 @@ const getTestTagHeader = (version: number, flags: Id3v2TagHeaderFlags, tagSize: 
         const tag = Id3v2Tag.fromEmpty();
 
         // Act / Assert
-        Testers.testTruthy((ident: Id3v2FrameIdentifier) => tag.setUrlFrame(ident, ""));
+        Testers.testTruthy((ident: FrameIdentifier) => tag.setUrlFrame(ident, ""));
     }
 
     @test
@@ -2166,9 +2165,9 @@ const getTestTagHeader = (version: number, flags: Id3v2TagHeaderFlags, tagSize: 
         const tag = Id3v2Tag.fromEmpty();
 
         // Act / Assert
-        assert.throws(() => tag.setUrlFrame(Id3v2FrameIdentifiers.TXXX, ""));
-        assert.throws(() => tag.setUrlFrame(Id3v2FrameIdentifiers.RVRB, ""));
-        assert.throws(() => tag.setUrlFrame(Id3v2FrameIdentifiers.SYLT, ""));
+        assert.throws(() => tag.setUrlFrame(FrameIdentifiers.TXXX, ""));
+        assert.throws(() => tag.setUrlFrame(FrameIdentifiers.RVRB, ""));
+        assert.throws(() => tag.setUrlFrame(FrameIdentifiers.SYLT, ""));
     }
 
     @params("", "empty string")
@@ -2176,16 +2175,16 @@ const getTestTagHeader = (version: number, flags: Id3v2TagHeaderFlags, tagSize: 
     @params(undefined, "undefined")
     public setUrlFrame_falsy_removesFrame(text: string) {
         // Arrange
-        const frame1 = UrlLinkFrame.fromIdentity(Id3v2FrameIdentifiers.WCOM);
+        const frame1 = UrlLinkFrame.fromIdentity(FrameIdentifiers.WCOM);
         frame1.text = "foo";
-        const frame2 = UrlLinkFrame.fromIdentity(Id3v2FrameIdentifiers.WCOM);
+        const frame2 = UrlLinkFrame.fromIdentity(FrameIdentifiers.WCOM);
         frame2.text = "bar";
 
         const tag = Id3v2Tag.fromEmpty();
         tag.frames.push(frame1, frame2);
 
         // Act
-        tag.setUrlFrame(Id3v2FrameIdentifiers.WCOM, text);
+        tag.setUrlFrame(FrameIdentifiers.WCOM, text);
 
         // Assert
         assert.isTrue(tag.isEmpty);

--- a/test-unit/id3v2/id3v2TagTests.ts
+++ b/test-unit/id3v2/id3v2TagTests.ts
@@ -2097,24 +2097,47 @@ const getTestTagHeader = (version: number, flags: Id3v2TagHeaderFlags, tagSize: 
     }
 
     @test
-    public setTextFrame_invalidArgs() {
+    public setTextFrame_falsyIdentifier() {
         // Arrange
         const tag = Id3v2Tag.fromEmpty();
 
         // Act / Assert
-        assert.throws(() => { tag.setTextFrame(undefined, "foo"); });
-        assert.throws(() => { tag.setTextFrame(null, "foo"); });
+        Testers.testTruthy((v: FrameIdentifier) => tag.setTextFrame(v, "foo"));
+    }
+
+    @params(FrameIdentifiers.WXXX, "WXXX")
+    @params(FrameIdentifiers.RVRB, "RVRB")
+    @params(FrameIdentifiers.SYLT, "SYLT")
+    public setUrlFrame_notTextFrame(identifier: FrameIdentifier) {
+        // Arrange
+        const tag = Id3v2Tag.fromEmpty();
+
+        // Act / Assert
+        assert.throws(() => tag.setTextFrame(identifier, ""));
     }
 
     @test
-    public setTextFrame_removesFrame() {
+    public setTextFrame_userTextFrame() {
         // Arrange
         const tag = Id3v2Tag.fromEmpty();
-        const frame = TextInformationFrame.fromIdentifier(FrameIdentifiers.TCOM);
-        tag.frames.push(frame);
+
+        // Act / Assert
+        assert.throws(() => tag.setTextFrame(FrameIdentifiers.TXXX, "foo"));
+    }
+
+    @test
+    public setTextFrame_falsyValues_removesFrame() {
+        // Arrange
+        const frame1 = TextInformationFrame.fromIdentifier(FrameIdentifiers.TCOM);
+        frame1.text = ["foo"];
+        const frame2 = TextInformationFrame.fromIdentifier(FrameIdentifiers.TCOM);
+        frame2.text = ["bar"];
+
+        const tag = Id3v2Tag.fromEmpty();
+        tag.frames.push(frame1, frame2);
 
         // Act
-        tag.setTextFrame(FrameIdentifiers.TCOM, undefined, undefined, undefined);
+        tag.setTextFrame(FrameIdentifiers.TCOM, undefined, null, "");
 
         // Assert
         assert.strictEqual(tag.frames.length, 0);
@@ -2159,21 +2182,30 @@ const getTestTagHeader = (version: number, flags: Id3v2TagHeaderFlags, tagSize: 
         Testers.testTruthy((ident: FrameIdentifier) => tag.setUrlFrame(ident, ""));
     }
 
-    @test
-    public setUrlFrame_notUrlFrame() {
+    @params(FrameIdentifiers.TXXX, "TXXX")
+    @params(FrameIdentifiers.RVRB, "RVRB")
+    @params(FrameIdentifiers.SYLT, "SYLT")
+    public setUrlFrame_notUrlFrame(identifier: FrameIdentifier) {
         // Arrange
         const tag = Id3v2Tag.fromEmpty();
 
         // Act / Assert
-        assert.throws(() => tag.setUrlFrame(FrameIdentifiers.TXXX, ""));
-        assert.throws(() => tag.setUrlFrame(FrameIdentifiers.RVRB, ""));
-        assert.throws(() => tag.setUrlFrame(FrameIdentifiers.SYLT, ""));
+        assert.throws(() => tag.setUrlFrame(identifier, ""));
+    }
+
+    @test
+    public setUrlFrame_userUrlFrame() {
+        // Arrange
+        const tag = Id3v2Tag.fromEmpty();
+
+        // Act / Assert
+        assert.throws(() => tag.setUrlFrame(FrameIdentifiers.WXXX, "foo"));
     }
 
     @params("", "empty string")
     @params(null, "null")
     @params(undefined, "undefined")
-    public setUrlFrame_falsy_removesFrame(text: string) {
+    public setUrlFrame_falsyValue_removesFrame(text: string) {
         // Arrange
         const frame1 = UrlLinkFrame.fromIdentity(FrameIdentifiers.WCOM);
         frame1.text = "foo";

--- a/test-unit/id3v2/id3v2TagTests.ts
+++ b/test-unit/id3v2/id3v2TagTests.ts
@@ -1,5 +1,5 @@
 import * as TypeMoq from "typemoq";
-import {suite, test} from "@testdeck/mocha";
+import {params, suite, test} from "@testdeck/mocha";
 import {assert} from "chai";
 
 import CommentsFrame from "../../src/id3v2/frames/commentsFrame";
@@ -25,6 +25,7 @@ import {Testers} from "../utilities/testers";
 import {TextInformationFrame, UserTextInformationFrame} from "../../src/id3v2/frames/textInformationFrame";
 import {UrlLinkFrame} from "../../src/id3v2/frames/urlLinkFrame";
 import PrivateFrame from "../../src/id3v2/frames/privateFrame";
+import {Id3v2FrameIdentifier, Id3v2FrameIdentifiers, Id3v2UrlLinkFrame} from "../../src";
 
 const getTestTagHeader = (version: number, flags: Id3v2TagHeaderFlags, tagSize: number): ByteVector => {
     return ByteVector.concatenate(
@@ -1711,9 +1712,9 @@ const getTestTagHeader = (version: number, flags: Id3v2TagHeaderFlags, tagSize: 
         const tag = Id3v2Tag.fromEmpty();
         const frame1 = TextInformationFrame.fromIdentifier(FrameIdentifiers.TCOM);
         const frame2 = UrlLinkFrame.fromIdentity(FrameIdentifiers.WCOM);
-        frame2.text = ["foo"];
+        frame2.text = "foo";
         const frame3 = UrlLinkFrame.fromIdentity(FrameIdentifiers.WCOM);
-        frame3.text = ["bar"];
+        frame3.text = "bar";
         tag.frames.push(frame1, frame2, frame3);
 
         // Act
@@ -2121,36 +2122,6 @@ const getTestTagHeader = (version: number, flags: Id3v2TagHeaderFlags, tagSize: 
     }
 
     @test
-    public setTextFrame_urlFrameNoMatch() {
-        // Arrange
-        const tag = Id3v2Tag.fromEmpty();
-
-        // Act
-        tag.setTextFrame(FrameIdentifiers.WCOM, "foo", "bar");
-
-        // Assert
-        assert.strictEqual(tag.frames.length, 1);
-        assert.strictEqual(tag.frames[0].frameId, FrameIdentifiers.WCOM);
-        assert.deepStrictEqual((<UrlLinkFrame> tag.frames[0]).text, ["foo", "bar"]);
-    }
-
-    @test
-    public setTextFrame_urlFrameWithMatch() {
-        // Arrange
-        const tag = Id3v2Tag.fromEmpty();
-        const frame = UrlLinkFrame.fromIdentity(FrameIdentifiers.WCOM);
-        frame.text = ["fux", "qux"];
-
-        // Act
-        tag.setTextFrame(FrameIdentifiers.WCOM, "foo", "bar");
-
-        // Assert
-        assert.strictEqual(tag.frames.length, 1);
-        assert.strictEqual(tag.frames[0].frameId, FrameIdentifiers.WCOM);
-        assert.deepStrictEqual((<UrlLinkFrame> tag.frames[0]).text, ["foo", "bar"]);
-    }
-
-    @test
     public setTextFrame_textFrameNoMatch() {
         // Arrange
         const tag = Id3v2Tag.fromEmpty();
@@ -2178,5 +2149,75 @@ const getTestTagHeader = (version: number, flags: Id3v2TagHeaderFlags, tagSize: 
         assert.strictEqual(tag.frames.length, 1);
         assert.strictEqual(tag.frames[0].frameId, FrameIdentifiers.TCOM);
         assert.deepStrictEqual((<TextInformationFrame> tag.frames[0]).text, ["foo", "bar"]);
+    }
+
+    @test
+    public setUrlFrame_falsyIdentifier() {
+        // Arrange
+        const tag = Id3v2Tag.fromEmpty();
+
+        // Act / Assert
+        Testers.testTruthy((ident: Id3v2FrameIdentifier) => tag.setUrlFrame(ident, ""));
+    }
+
+    @test
+    public setUrlFrame_notUrlFrame() {
+        // Arrange
+        const tag = Id3v2Tag.fromEmpty();
+
+        // Act / Assert
+        assert.throws(() => tag.setUrlFrame(Id3v2FrameIdentifiers.TXXX, ""));
+        assert.throws(() => tag.setUrlFrame(Id3v2FrameIdentifiers.RVRB, ""));
+        assert.throws(() => tag.setUrlFrame(Id3v2FrameIdentifiers.SYLT, ""));
+    }
+
+    @params("", "empty string")
+    @params(null, "null")
+    @params(undefined, "undefined")
+    public setUrlFrame_falsy_removesFrame(text: string) {
+        // Arrange
+        const frame1 = UrlLinkFrame.fromIdentity(Id3v2FrameIdentifiers.WCOM);
+        frame1.text = "foo";
+        const frame2 = UrlLinkFrame.fromIdentity(Id3v2FrameIdentifiers.WCOM);
+        frame2.text = "bar";
+
+        const tag = Id3v2Tag.fromEmpty();
+        tag.frames.push(frame1, frame2);
+
+        // Act
+        tag.setUrlFrame(Id3v2FrameIdentifiers.WCOM, text);
+
+        // Assert
+        assert.isTrue(tag.isEmpty);
+    }
+
+    @test
+    public setUrlFrame_withoutMatchingFrames_addsFrame() {
+        // Arrange
+        const tag = Id3v2Tag.fromEmpty();
+
+        // Act
+        tag.setUrlFrame(FrameIdentifiers.WCOM, "foo");
+
+        // Assert
+        assert.strictEqual(tag.frames.length, 1);
+        assert.strictEqual(tag.frames[0].frameId, FrameIdentifiers.WCOM);
+        assert.strictEqual((<UrlLinkFrame>tag.frames[0]).text, "foo");
+    }
+
+    @test
+    public setTextFrame_withMatchingFrames_updatesFrame() {
+        // Arrange
+        const tag = Id3v2Tag.fromEmpty();
+        const frame = UrlLinkFrame.fromIdentity(FrameIdentifiers.WCOM);
+        frame.text = "fux";
+
+        // Act
+        tag.setUrlFrame(FrameIdentifiers.WCOM, "foo");
+
+        // Assert
+        assert.strictEqual(tag.frames.length, 1);
+        assert.strictEqual(tag.frames[0].frameId, FrameIdentifiers.WCOM);
+        assert.strictEqual((<UrlLinkFrame>tag.frames[0]).text, "foo");
     }
 }

--- a/test-unit/id3v2/id3v2TagTests.ts
+++ b/test-unit/id3v2/id3v2TagTests.ts
@@ -2205,7 +2205,7 @@ const getTestTagHeader = (version: number, flags: Id3v2TagHeaderFlags, tagSize: 
     }
 
     @test
-    public setTextFrame_withMatchingFrames_updatesFrame() {
+    public setUrlFrame_withMatchingFrames_updatesFrame() {
         // Arrange
         const tag = Id3v2Tag.fromEmpty();
         const frame = UrlLinkFrame.fromIdentity(FrameIdentifiers.WCOM);

--- a/test-unit/id3v2/urlLinkFrameTests.ts
+++ b/test-unit/id3v2/urlLinkFrameTests.ts
@@ -1,4 +1,4 @@
-import {suite, test} from "@testdeck/mocha";
+import {params, suite, test} from "@testdeck/mocha";
 import {assert} from "chai";
 
 import FrameConstructorTests from "./frameConstructorTests";
@@ -199,5 +199,19 @@ const getTestUrlLinkFrame = (): UrlLinkFrame => {
         // Assert
         assert.isOk(result);
         Testers.bvEqual(result, getTestFrameData());
+    }
+
+    @params("", "empty string")
+    @params("foo", "foo")
+    public toString_returnsText(text: string) {
+        // Arrange
+        const frame = UrlLinkFrame.fromIdentity(FrameIdentifiers.WCOM);
+        frame.text = text;
+
+        // Act
+        const result = frame.toString();
+
+        // Assert
+        assert.strictEqual(result, text);
     }
 }

--- a/test-unit/id3v2/urlLinkFrameTests.ts
+++ b/test-unit/id3v2/urlLinkFrameTests.ts
@@ -2,7 +2,6 @@ import {params, suite, test} from "@testdeck/mocha";
 import {assert} from "chai";
 
 import FrameConstructorTests from "./frameConstructorTests";
-import TestConstants from "../testConstants";
 import {ByteVector, StringType} from "../../src/byteVector";
 import {Frame, FrameClassType} from "../../src/id3v2/frames/frame";
 import {Id3v2FrameFlags, Id3v2FrameHeader} from "../../src/id3v2/frames/frameHeader";
@@ -27,33 +26,27 @@ import {UrlLinkFrame} from "../../src/id3v2/frames/urlLinkFrame";
         const output = UrlLinkFrame.fromIdentity(FrameIdentifiers.WCOM);
 
         // Assert
-        Id3v2_UrlLinkFrame_ConstructorTests.assertFrame(output, FrameIdentifiers.WCOM, undefined);
+        assert.ok(output);
+        assert.strictEqual(output.frameClassType, FrameClassType.UrlLinkFrame);
+        assert.strictEqual(output.frameId, FrameIdentifiers.WCOM);
+        assert.strictEqual(output.text, undefined);
     }
 
     @test
-    public fromOffsetRawData_notUserFrame() {
+    public fromOffsetRawData_itsgood() {
         // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.WCOM);
-        header.frameSize = TestConstants.syncedUint;
-        const data = ByteVector.concatenate(
-            0x00, 0x00,
-            header.render(4),
-            ByteVector.fromString("foobar", StringType.Latin1),
-            0x00, 0x00 // Some null bytes to trigger null cleanup
-        );
+        const bodyBytes = ByteVector.fromString("foo", StringType.Latin1);
+        const header = new Id3v2FrameHeader(FrameIdentifiers.WCOM, Id3v2FrameFlags.None, bodyBytes.length);
+        const data = ByteVector.concatenate(header.render(4), bodyBytes);
 
         // Act
         const output = UrlLinkFrame.fromOffsetRawData(data, 2, header, 4);
 
         // Assert
-        Id3v2_UrlLinkFrame_ConstructorTests.assertFrame(output, FrameIdentifiers.WCOM, "foobar");
-    }
-
-    private static assertFrame(frame: UrlLinkFrame, ft: FrameIdentifier, t: string) {
-        assert.ok(frame);
-        assert.strictEqual(frame.frameClassType, FrameClassType.UrlLinkFrame);
-        assert.strictEqual(frame.frameId, ft);
-        assert.strictEqual(frame.text, t);
+        assert.ok(output);
+        assert.strictEqual(output.frameClassType, FrameClassType.UrlLinkFrame);
+        assert.strictEqual(output.frameId, FrameIdentifiers.WCOM);
+        assert.strictEqual(output.text, "foo");
     }
 }
 

--- a/test-unit/id3v2/urlLinkFrameTests.ts
+++ b/test-unit/id3v2/urlLinkFrameTests.ts
@@ -48,7 +48,7 @@ const getTestUrlLinkFrame = (): UrlLinkFrame => {
         const output = UrlLinkFrame.fromIdentity(FrameIdentifiers.WCOM);
 
         // Assert
-        Id3v2_UrlLinkFrame_ConstructorTests.assertFrame(output, FrameIdentifiers.WCOM, [], StringType.Latin1);
+        Id3v2_UrlLinkFrame_ConstructorTests.assertFrame(output, FrameIdentifiers.WCOM, undefined);
     }
 
     @test
@@ -67,101 +67,40 @@ const getTestUrlLinkFrame = (): UrlLinkFrame => {
         const output = UrlLinkFrame.fromOffsetRawData(data, 2, header, 4);
 
         // Assert
-        Id3v2_UrlLinkFrame_ConstructorTests.assertFrame(output, FrameIdentifiers.WCOM, ["foobar"], StringType.Latin1);
+        Id3v2_UrlLinkFrame_ConstructorTests.assertFrame(output, FrameIdentifiers.WCOM, "foobar");
     }
 
-    @test
-    public fromOffsetRawData_userFrame() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.WXXX);
-        header.frameSize = 12;
-        const data = ByteVector.concatenate(
-            0x00, 0x00,
-            header.render(4),
-            StringType.UTF16BE,
-            ByteVector.fromString("foo", StringType.UTF16BE),
-            ByteVector.getTextDelimiter(StringType.UTF16BE),
-            ByteVector.fromString("bar", StringType.Latin1)
-        );
-
-        // Act
-        const output = UrlLinkFrame.fromOffsetRawData(data, 2, header, 4);
-
-        // Assert
-        Id3v2_UrlLinkFrame_ConstructorTests.assertFrame(
-            output,
-            FrameIdentifiers.WXXX,
-            ["foo", "bar"],
-            StringType.Latin1
-        );
-    }
-
-    private static assertFrame(frame: UrlLinkFrame, ft: FrameIdentifier, t: string[], te: StringType) {
+    private static assertFrame(frame: UrlLinkFrame, ft: FrameIdentifier, t: string) {
         assert.ok(frame);
         assert.strictEqual(frame.frameClassType, FrameClassType.UrlLinkFrame);
         assert.strictEqual(frame.frameId, ft);
-
-        assert.deepEqual(frame.text, t);
-        assert.equal(frame.textEncoding, te);
+        assert.strictEqual(frame.text, t);
     }
 }
 
 @suite class Id3v2_UrlLinkFrame_PropertyTests {
     @test
-    public getText_outputIsClone() {
-        // Arrange
-        const frame = getTestUrlLinkFrame();
-
-        // Act
-        const text = frame.text;
-        text.push("baz");
-
-        // Assert
-        assert.deepEqual(frame.text, ["foo", "bar"]);
-    }
-
-    @test
     public setText_falsyValues() {
         // Arrange
         const frame = getTestUrlLinkFrame();
-        const set = (v: string[]) => { frame.text = v; };
+        const set = (v: string) => { frame.text = v; };
         const get = () => frame.text;
 
         // Act / Assert
-        PropertyTests.propertyNormalized(set, get, undefined, []);
-        PropertyTests.propertyNormalized(set, get, null, []);
+        PropertyTests.propertyNormalized(set, get, undefined, "");
+        PropertyTests.propertyNormalized(set, get, null, "");
     }
 
     @test
     public setText_values() {
         // Arrange
         const frame = getTestUrlLinkFrame();
-        const values = ["fux", "qux"];
 
         // Act
-        frame.text = values;
+        frame.text = "fux";
 
         // Assert
-        assert.deepEqual(frame.text, values);
-
-        // -- Ensure values are cloned
-        // Act 2
-        values.push("bux");
-
-        // Assert 2
-        assert.deepEqual(frame.text, ["fux", "qux"]);
-    }
-
-    @test
-    public setEncoding() {
-        // Arrange
-        const frame = getTestUrlLinkFrame();
-
-        // Act
-        frame.textEncoding = StringType.UTF8;
-
-        // Assert
-        assert.equal(frame.textEncoding, StringType.UTF8);
+        assert.strictEqual(frame.text, "fux");
     }
 }
 
@@ -230,8 +169,7 @@ const getTestUrlLinkFrame = (): UrlLinkFrame => {
         // Assert
         assert.isOk(result);
         assert.strictEqual(result.frameId, frame.frameId);
-        assert.deepEqual(result.text, frame.text);
-        assert.deepEqual(result.textEncoding, frame.textEncoding);
+        assert.strictEqual(result.text, frame.text);
     }
 
     @test
@@ -247,8 +185,7 @@ const getTestUrlLinkFrame = (): UrlLinkFrame => {
         // Assert
         assert.isOk(result);
         assert.strictEqual(result.frameId, frame.frameId);
-        assert.deepEqual(result.text, frame.text);
-        assert.deepEqual(result.textEncoding, frame.textEncoding);
+        assert.strictEqual(result.text, frame.text);
     }
 
     @test

--- a/test-unit/id3v2/urlLinkFrameTests.ts
+++ b/test-unit/id3v2/urlLinkFrameTests.ts
@@ -2,34 +2,13 @@ import {params, suite, test} from "@testdeck/mocha";
 import {assert} from "chai";
 
 import FrameConstructorTests from "./frameConstructorTests";
-import PropertyTests from "../utilities/propertyTests";
 import TestConstants from "../testConstants";
 import {ByteVector, StringType} from "../../src/byteVector";
 import {Frame, FrameClassType} from "../../src/id3v2/frames/frame";
-import {Id3v2FrameHeader} from "../../src/id3v2/frames/frameHeader";
+import {Id3v2FrameFlags, Id3v2FrameHeader} from "../../src/id3v2/frames/frameHeader";
 import {FrameIdentifier, FrameIdentifiers} from "../../src/id3v2/frameIdentifiers";
 import {Testers} from "../utilities/testers";
 import {UrlLinkFrame} from "../../src/id3v2/frames/urlLinkFrame";
-
-const getTestFrameData = (): ByteVector => {
-    const header = new Id3v2FrameHeader(FrameIdentifiers.WXXX);
-    header.frameSize = 8;
-
-    return ByteVector.concatenate(
-        header.render(4),
-        StringType.Latin1,
-        ByteVector.fromString("foo", StringType.Latin1),
-        ByteVector.getTextDelimiter(StringType.Latin1),
-        ByteVector.fromString("bar", StringType.Latin1)
-    );
-};
-
-const getTestUrlLinkFrame = (): UrlLinkFrame => {
-    const header = new Id3v2FrameHeader(FrameIdentifiers.WXXX);
-    header.frameSize = 8;
-    const frameData = getTestFrameData();
-    return UrlLinkFrame.fromOffsetRawData(frameData, 0, header, 4);
-};
 
 @suite class Id3v2_UrlLinkFrame_ConstructorTests extends FrameConstructorTests {
     public get fromOffsetRawData(): (d: ByteVector, o: number, h: Id3v2FrameHeader, v: number) => Frame {
@@ -79,28 +58,19 @@ const getTestUrlLinkFrame = (): UrlLinkFrame => {
 }
 
 @suite class Id3v2_UrlLinkFrame_PropertyTests {
-    @test
-    public setText_falsyValues() {
+    @params(undefined, "undefined")
+    @params(null, "null")
+    @params("", "empty_string")
+    @params("bar", "truthy")
+    public setText_falsyValues(value: string) {
         // Arrange
-        const frame = getTestUrlLinkFrame();
-        const set = (v: string) => { frame.text = v; };
-        const get = () => frame.text;
-
-        // Act / Assert
-        PropertyTests.propertyNormalized(set, get, undefined, "");
-        PropertyTests.propertyNormalized(set, get, null, "");
-    }
-
-    @test
-    public setText_values() {
-        // Arrange
-        const frame = getTestUrlLinkFrame();
+        const frame = UrlLinkFrame.fromIdentity(FrameIdentifiers.WCOM);
 
         // Act
-        frame.text = "fux";
+        frame.text = value;
 
         // Assert
-        assert.strictEqual(frame.text, "fux");
+        assert.strictEqual(frame.text, value);
     }
 }
 
@@ -114,7 +84,7 @@ const getTestUrlLinkFrame = (): UrlLinkFrame => {
     @test
     public findUrlLinkFrame_falsyIdentity_throws(): void {
         // Arrange
-        const frames = [getTestUrlLinkFrame()];
+        const frames = [UrlLinkFrame.fromIdentity(FrameIdentifiers.WCOM)];
 
         // Act/Assert
         Testers.testTruthy((v: FrameIdentifier) => { UrlLinkFrame.findUrlLinkFrame(frames, v); });
@@ -135,10 +105,13 @@ const getTestUrlLinkFrame = (): UrlLinkFrame => {
     @test
     public findUrlLinkFrame_noMatch_returnsUndefined() {
         // Arrange
-        const frames = [getTestUrlLinkFrame(), getTestUrlLinkFrame()]; // Type is WXXX
+        const frames = [
+            UrlLinkFrame.fromIdentity(FrameIdentifiers.WCOM),
+            UrlLinkFrame.fromIdentity(FrameIdentifiers.WCOP)
+        ];
 
         // Act
-        const result = UrlLinkFrame.findUrlLinkFrame(frames, FrameIdentifiers.WCOM);
+        const result = UrlLinkFrame.findUrlLinkFrame(frames, FrameIdentifiers.WPAY);
 
         // Assert
         assert.isUndefined(result);
@@ -147,21 +120,22 @@ const getTestUrlLinkFrame = (): UrlLinkFrame => {
     @test
     public findUrlLinkFrame_match_returnsFirstMatch() {
         // Arrange
-        const frame1 = getTestUrlLinkFrame();
-        const frame2 = getTestUrlLinkFrame();
+        const frame1 = UrlLinkFrame.fromIdentity(FrameIdentifiers.WCOM);
+        const frame2 = UrlLinkFrame.fromIdentity(FrameIdentifiers.WCOM);
         const frames = [frame1, frame2];
 
         // Act
-        const result = UrlLinkFrame.findUrlLinkFrame(frames, FrameIdentifiers.WXXX);
+        const result = UrlLinkFrame.findUrlLinkFrame(frames, FrameIdentifiers.WCOM);
 
         // Assert
         assert.equal(result, frame1);
     }
 
     @test
-    public clone_withRawData_returnsCloneUsingRawData() {
+    public clone_returnsCloneUsingRawData() {
         // Arrange
-        const frame = getTestUrlLinkFrame();
+        const frame = UrlLinkFrame.fromIdentity(FrameIdentifiers.WCOM);
+        frame.text = "foo";
 
         // Act
         const result = frame.clone();
@@ -173,35 +147,40 @@ const getTestUrlLinkFrame = (): UrlLinkFrame => {
     }
 
     @test
-    public clone_withoutRawData_returnsClone() {
+    public render_withoutText() {
         // Arrange
-        const frame = getTestUrlLinkFrame();
-        // noinspection JSUnusedLocalSymbols Forces a read of the raw data
-        const _ = frame.text;
-
-        // Act
-        const result = frame.clone();
-
-        // Assert
-        assert.isOk(result);
-        assert.strictEqual(result.frameId, frame.frameId);
-        assert.strictEqual(result.text, frame.text);
-    }
-
-    @test
-    public render_returnsByteVector() {
-        // Arrange
-        const frame = getTestUrlLinkFrame();
+        const frame = UrlLinkFrame.fromIdentity(FrameIdentifiers.WCOM);
 
         // Act
         const result = frame.render(4);
 
         // Assert
         assert.isOk(result);
-        Testers.bvEqual(result, getTestFrameData());
+        assert.strictEqual(result.length, 0);
     }
 
-    @params("", "empty string")
+    @test
+    public render_withText() {
+        // Arrange
+        const frame = UrlLinkFrame.fromIdentity(FrameIdentifiers.WCOM);
+        frame.text = "foo";
+
+        // Act
+        const result = frame.render(4);
+
+        // Assert
+        assert.isOk(result);
+
+        const expectedBytes = ByteVector.concatenate(
+            FrameIdentifiers.WCOM.render(4),
+            ByteVector.fromUint(3),
+            ByteVector.fromUshort(Id3v2FrameFlags.None),
+            ByteVector.fromString("foo", StringType.Latin1)
+        );
+        Testers.bvEqual(result, expectedBytes);
+    }
+
+    @params("", "empty_string")
     @params("foo", "foo")
     public toString_returnsText(text: string) {
         // Arrange

--- a/test-unit/id3v2/urlLinkFrameTests.ts
+++ b/test-unit/id3v2/urlLinkFrameTests.ts
@@ -33,14 +33,56 @@ import {UrlLinkFrame} from "../../src/id3v2/frames/urlLinkFrame";
     }
 
     @test
-    public fromOffsetRawData_itsgood() {
+    public fromOffsetRawData_itsGood() {
         // Arrange
         const bodyBytes = ByteVector.fromString("foo", StringType.Latin1);
         const header = new Id3v2FrameHeader(FrameIdentifiers.WCOM, Id3v2FrameFlags.None, bodyBytes.length);
         const data = ByteVector.concatenate(header.render(4), bodyBytes);
 
         // Act
-        const output = UrlLinkFrame.fromOffsetRawData(data, 2, header, 4);
+        const output = UrlLinkFrame.fromOffsetRawData(data, 0, header, 4);
+
+        // Assert
+        assert.ok(output);
+        assert.strictEqual(output.frameClassType, FrameClassType.UrlLinkFrame);
+        assert.strictEqual(output.frameId, FrameIdentifiers.WCOM);
+        assert.strictEqual(output.text, "foo");
+    }
+
+    @test
+    public fromOffsetRawData_trailingNullBytes() {
+        // Arrange
+        const bodyBytes = ByteVector.concatenate(
+            ByteVector.fromString("foo", StringType.Latin1),
+            0x00, 0x00
+        );
+        const header = new Id3v2FrameHeader(FrameIdentifiers.WCOM, Id3v2FrameFlags.None, bodyBytes.length);
+        const data = ByteVector.concatenate(header.render(4), bodyBytes);
+
+        // Act
+        const output = UrlLinkFrame.fromOffsetRawData(data, 0, header, 4);
+
+        // Assert
+        assert.ok(output);
+        assert.strictEqual(output.frameClassType, FrameClassType.UrlLinkFrame);
+        assert.strictEqual(output.frameId, FrameIdentifiers.WCOM);
+        assert.strictEqual(output.text, "foo");
+    }
+
+    @test
+    public fromOffsetRawData_multipleFields() {
+        // Arrange
+        const bodyBytes = ByteVector.concatenate(
+            ByteVector.fromString("foo", StringType.Latin1),
+            0x00,
+            ByteVector.fromString("bar", StringType.Latin1),
+            0x00, 0x00
+        );
+        const header = new Id3v2FrameHeader(FrameIdentifiers.WCOM, Id3v2FrameFlags.None, bodyBytes.length);
+        const data = ByteVector.concatenate(header.render(4), bodyBytes);
+
+        // Act
+        const output = UrlLinkFrame.fromOffsetRawData(data, 0, header, 4);
 
         // Assert
         assert.ok(output);

--- a/test-unit/id3v2/userUrlLinkFrameTests.ts
+++ b/test-unit/id3v2/userUrlLinkFrameTests.ts
@@ -4,7 +4,7 @@ import {assert} from "chai";
 import FrameConstructorTests from "./frameConstructorTests";
 import {ByteVector, StringType} from "../../src/byteVector";
 import {Frame, FrameClassType} from "../../src/id3v2/frames/frame";
-import {Id3v2FrameHeader} from "../../src/id3v2/frames/frameHeader";
+import {Id3v2FrameFlags, Id3v2FrameHeader} from "../../src/id3v2/frames/frameHeader";
 import {FrameIdentifiers} from "../../src/id3v2/frameIdentifiers";
 import {Testers} from "../utilities/testers";
 import {UserUrlLinkFrame} from "../../src/id3v2/frames/urlLinkFrame";
@@ -35,17 +35,19 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
     }
 
     @test
-    public fromOffsetRawData_userFrame() {
+    public fromOffsetRawData_latin1() {
         // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.WXXX);
-        header.frameSize = 8;
-        const data = ByteVector.concatenate(
-            0x00, 0x00,
-            header.render(4),
+        const bodyBytes = ByteVector.concatenate(
             StringType.Latin1,
             ByteVector.fromString("foo", StringType.Latin1),
             ByteVector.getTextDelimiter(StringType.Latin1),
             ByteVector.fromString("bar", StringType.Latin1)
+        );
+        const header = new Id3v2FrameHeader(FrameIdentifiers.WXXX, Id3v2FrameFlags.None, bodyBytes.length);
+        const data = ByteVector.concatenate(
+            0x00, 0x00,
+            header.render(4),
+            bodyBytes
         );
 
         // Act
@@ -57,8 +59,37 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
         assert.strictEqual(output.frameId, FrameIdentifiers.WXXX);
 
         assert.strictEqual(output.description, "foo");
-        assert.deepEqual(output.text, ["bar"]);
+        assert.strictEqual(output.text, "bar");
         assert.equal(output.textEncoding, StringType.Latin1);
+    }
+
+    @test
+    public fromOffsetRawData_utf16() {
+        // Arrange
+        const bodyBytes = ByteVector.concatenate(
+            StringType.UTF16BE,
+            ByteVector.fromString("foo", StringType.UTF16BE),
+            ByteVector.getTextDelimiter(StringType.UTF16BE),
+            ByteVector.fromString("bar", StringType.Latin1)
+        );
+        const header = new Id3v2FrameHeader(FrameIdentifiers.WXXX, Id3v2FrameFlags.None, bodyBytes.length);
+        const data = ByteVector.concatenate(
+            0x00, 0x00,
+            header.render(4),
+            bodyBytes
+        );
+
+        // Act
+        const output = UserUrlLinkFrame.fromOffsetRawData(data, 2, header, 4);
+
+        // Assert
+        assert.ok(output);
+        assert.equal(output.frameClassType, FrameClassType.UserUrlLinkFrame);
+        assert.strictEqual(output.frameId, FrameIdentifiers.WXXX);
+
+        assert.strictEqual(output.description, "foo");
+        assert.strictEqual(output.text, "bar");
+        assert.strictEqual(output.textEncoding, StringType.UTF16BE);
     }
 
 }
@@ -88,7 +119,7 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
 
         // Assert
         assert.isUndefined(frame.description);
-        assert.deepEqual(frame.text, ["bar"]);
+        assert.strictEqual(frame.text, "bar");
     }
 
     @test
@@ -101,7 +132,7 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
 
         // Assert
         assert.isUndefined(frame.description);
-        assert.deepEqual(frame.text, ["bar"]);
+        assert.strictEqual(frame.text, "bar");
     }
 
     @test
@@ -114,7 +145,7 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
 
         // Assert
         assert.strictEqual(frame.description, "fux");
-        assert.deepEqual(frame.text, ["bar"]);
+        assert.strictEqual(frame.text, "bar");
     }
 
     @test
@@ -133,21 +164,7 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
 
         // Assert
         assert.strictEqual(frame.description, "fux");
-        assert.deepEqual(frame.text, []);
-    }
-
-    @test
-    public getText_outputIsClone() {
-        // Arrange
-        const frame = getTestUserUrlLinkFrame();
-
-        // Act
-        const text = frame.text;
-        text.push("baz");
-
-        // Assert
-        assert.strictEqual(frame.description, "foo");
-        assert.deepEqual(frame.text, ["bar"]);
+        assert.strictEqual(frame.text, "");
     }
 
     @test
@@ -160,7 +177,7 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
 
         // Assert
         assert.strictEqual(frame.description, "foo");
-        assert.deepEqual(frame.text, []);
+        assert.strictEqual(frame.text, "");
     }
 
     @test
@@ -173,29 +190,21 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
 
         // Assert
         assert.strictEqual(frame.description, "foo");
-        assert.deepEqual(frame.text, []);
+        assert.strictEqual(frame.text, "");
     }
 
     @test
     public setText_values() {
         // Arrange
         const frame = getTestUserUrlLinkFrame();
-        const values = ["fux", "qux"];
+        const value = "fux";
 
         // Act
-        frame.text = values;
+        frame.text = value;
 
         // Assert
         assert.strictEqual(frame.description, "foo");
-        assert.deepEqual(frame.text, values);
-
-        // -- Ensure values are cloned
-        // Act 2
-        values.push("bux");
-
-        // Assert 2
-        assert.strictEqual(frame.description, "foo");
-        assert.deepEqual(frame.text, ["fux", "qux"]);
+        assert.strictEqual(frame.text, value);
     }
 
     @test
@@ -277,8 +286,8 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
         assert.isOk(result);
         assert.strictEqual(result.frameId, frame.frameId);
         assert.strictEqual(result.description, frame.description);
-        assert.deepEqual(result.text, frame.text);
-        assert.deepEqual(result.textEncoding, frame.textEncoding);
+        assert.strictEqual(result.text, frame.text);
+        assert.strictEqual(result.textEncoding, frame.textEncoding);
     }
 
     @test
@@ -295,7 +304,7 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
         assert.isOk(result);
         assert.strictEqual(result.frameId, frame.frameId);
         assert.strictEqual(result.description, frame.description);
-        assert.deepEqual(result.text, frame.text);
+        assert.strictEqual(result.text, frame.text);
         assert.strictEqual(result.textEncoding, frame.textEncoding);
     }
 

--- a/test-unit/id3v2/userUrlLinkFrameTests.ts
+++ b/test-unit/id3v2/userUrlLinkFrameTests.ts
@@ -1,4 +1,4 @@
-import {suite, test} from "@testdeck/mocha";
+import {params, suite, test} from "@testdeck/mocha";
 import {assert} from "chai";
 
 import FrameConstructorTests from "./frameConstructorTests";
@@ -7,7 +7,7 @@ import {Frame, FrameClassType} from "../../src/id3v2/frames/frame";
 import {Id3v2FrameFlags, Id3v2FrameHeader} from "../../src/id3v2/frames/frameHeader";
 import {FrameIdentifiers} from "../../src/id3v2/frameIdentifiers";
 import {Testers} from "../utilities/testers";
-import {UserUrlLinkFrame} from "../../src/id3v2/frames/urlLinkFrame";
+import {UrlLinkFrame, UserUrlLinkFrame} from "../../src/id3v2/frames/urlLinkFrame";
 
 const getTestFrameData = (): ByteVector => {
     const header = new Id3v2FrameHeader(FrameIdentifiers.WXXX);
@@ -32,6 +32,17 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
 @suite class Id3v2_UserUrlLinkFrame_ConstructorTests extends FrameConstructorTests {
     public get fromOffsetRawData(): (d: ByteVector, o: number, h: Id3v2FrameHeader, v: number) => Frame {
         return UserUrlLinkFrame.fromOffsetRawData;
+    }
+
+    @test
+    public fromOffsetRawData_tooSmall() {
+        // Arrange
+        const bodyBytes = ByteVector.fromSize(1);
+        const header = new Id3v2FrameHeader(FrameIdentifiers.WXXX, Id3v2FrameFlags.None, bodyBytes.length);
+        const data = ByteVector.concatenate(header.render(4), bodyBytes);
+
+        // Act / Assert
+        assert.throws(() => UserUrlLinkFrame.fromOffsetRawData(data, 0, header, 4));
     }
 
     @test
@@ -92,6 +103,51 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
         assert.strictEqual(output.textEncoding, StringType.UTF16BE);
     }
 
+    @test
+    public fromOffsetRawData_illFormedTagLib() {
+        // Arrange
+        const bodyBytes = ByteVector.concatenate(
+            StringType.UTF16BE,
+            ByteVector.fromString("foo/bar", StringType.UTF16BE)
+        );
+        const header = new Id3v2FrameHeader(FrameIdentifiers.WXXX, Id3v2FrameFlags.None, bodyBytes.length);
+        const data = ByteVector.concatenate(header.render(4), bodyBytes);
+
+        // Act
+        const output = UserUrlLinkFrame.fromOffsetRawData(data, 0, header, 4);
+
+        // Assert
+        assert.ok(output);
+        assert.equal(output.frameClassType, FrameClassType.UserUrlLinkFrame);
+        assert.strictEqual(output.frameId, FrameIdentifiers.WXXX);
+
+        assert.strictEqual(output.description, "foo");
+        assert.strictEqual(output.text, "bar");
+        assert.strictEqual(output.textEncoding, StringType.UTF16BE);
+    }
+
+    @test
+    public fromOffsetRawData_illFormedOneField() {
+        // Arrange
+        const bodyBytes = ByteVector.concatenate(
+            StringType.UTF16BE,
+            ByteVector.fromString("foo", StringType.UTF16BE)
+        );
+        const header = new Id3v2FrameHeader(FrameIdentifiers.WXXX, Id3v2FrameFlags.None, bodyBytes.length);
+        const data = ByteVector.concatenate(header.render(4), bodyBytes);
+
+        // Act
+        const output = UserUrlLinkFrame.fromOffsetRawData(data, 0, header, 4);
+
+        // Assert
+        assert.ok(output);
+        assert.equal(output.frameClassType, FrameClassType.UserUrlLinkFrame);
+        assert.strictEqual(output.frameId, FrameIdentifiers.WXXX);
+
+        assert.strictEqual(output.description, undefined);
+        assert.strictEqual(output.text, "foo");
+        assert.strictEqual(output.textEncoding, StringType.UTF16BE);
+    }
 }
 
 @suite class Id3v2_UserUrlLinkFrame_PropertyTests {
@@ -297,5 +353,21 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
         // Assert
         assert.isOk(result);
         Testers.bvEqual(result, getTestFrameData());
+    }
+
+    @params(["", ""], "empty string")
+    @params(["foo", ""], "foo+empty string")
+    @params(["", "foo"], "empty string+foo")
+    @params(["foo", "bar"], "foo+bar")
+    public toString_returnsText([description, text]: [string, string]) {
+        // Arrange
+        const frame = UserUrlLinkFrame.fromDescription(description);
+        frame.text = text;
+
+        // Act
+        const result = frame.toString();
+
+        // Assert
+        assert.strictEqual(result, `[${description}] ${text}`);
     }
 }

--- a/test-unit/id3v2/userUrlLinkFrameTests.ts
+++ b/test-unit/id3v2/userUrlLinkFrameTests.ts
@@ -98,9 +98,7 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
     @test
     public getDescription_emptyText_returnsUndefined() {
         // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.WXXX);
-        const data = header.render(4);
-        const frame = UserUrlLinkFrame.fromOffsetRawData(data, 0, header, 4);
+        const frame = UserUrlLinkFrame.fromDescription(undefined);
 
         // Act
         const result = frame.description;
@@ -123,19 +121,6 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
     }
 
     @test
-    public setDescription_existingDescription_null() {
-        // Arrange
-        const frame = getTestUserUrlLinkFrame();
-
-        // Act
-        frame.description = null;
-
-        // Assert
-        assert.isUndefined(frame.description);
-        assert.strictEqual(frame.text, "bar");
-    }
-
-    @test
     public setDescription_existingDescription_value() {
         // Arrange
         const frame = getTestUserUrlLinkFrame();
@@ -151,20 +136,13 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
     @test
     public setDescription_noDescription_value() {
         // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.WXXX);
-        header.frameSize = 0;
-        const data = ByteVector.concatenate(
-            header.render(4),
-            0x00, 0x00,                 // - Frame flags
-        );
-        const frame = UserUrlLinkFrame.fromOffsetRawData(data, 0, header, 4);
+        const frame = UserUrlLinkFrame.fromDescription(undefined);
 
         // Act
         frame.description = "fux";
 
         // Assert
         assert.strictEqual(frame.description, "fux");
-        assert.strictEqual(frame.text, "");
     }
 
     @test

--- a/test-unit/id3v2/userUrlLinkFrameTests.ts
+++ b/test-unit/id3v2/userUrlLinkFrameTests.ts
@@ -2,36 +2,30 @@ import {params, suite, test} from "@testdeck/mocha";
 import {assert} from "chai";
 
 import FrameConstructorTests from "./frameConstructorTests";
+import Id3v2Settings from "../../src/id3v2/id3v2Settings";
 import {ByteVector, StringType} from "../../src/byteVector";
 import {Frame, FrameClassType} from "../../src/id3v2/frames/frame";
 import {Id3v2FrameFlags, Id3v2FrameHeader} from "../../src/id3v2/frames/frameHeader";
 import {FrameIdentifiers} from "../../src/id3v2/frameIdentifiers";
 import {Testers} from "../utilities/testers";
-import {UrlLinkFrame, UserUrlLinkFrame} from "../../src/id3v2/frames/urlLinkFrame";
-
-const getTestFrameData = (): ByteVector => {
-    const header = new Id3v2FrameHeader(FrameIdentifiers.WXXX);
-    header.frameSize = 12;
-
-    return ByteVector.concatenate(
-        header.render(4),
-        StringType.UTF16BE,
-        ByteVector.fromString("foo", StringType.UTF16BE),
-        ByteVector.getTextDelimiter(StringType.UTF16BE),
-        ByteVector.fromString("bar", StringType.Latin1)
-    );
-};
-
-const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
-    const header = new Id3v2FrameHeader(FrameIdentifiers.WXXX);
-    header.frameSize = 12;
-    const frameData = getTestFrameData();
-    return UserUrlLinkFrame.fromOffsetRawData(frameData, 0, header, 4);
-};
+import {UserUrlLinkFrame} from "../../src/id3v2/frames/urlLinkFrame";
 
 @suite class Id3v2_UserUrlLinkFrame_ConstructorTests extends FrameConstructorTests {
     public get fromOffsetRawData(): (d: ByteVector, o: number, h: Id3v2FrameHeader, v: number) => Frame {
         return UserUrlLinkFrame.fromOffsetRawData;
+    }
+
+    @test
+    public fromFields() {
+        // Act
+        const frame = UserUrlLinkFrame.fromFields("foo", "bar");
+
+        // Assert
+        assert.isOk(frame);
+        assert.strictEqual(frame.frameId, FrameIdentifiers.WXXX);
+        assert.strictEqual(frame.description, "foo");
+        assert.strictEqual(frame.text, "bar");
+        assert.strictEqual(frame.textEncoding, Id3v2Settings.defaultEncoding);
     }
 
     @test
@@ -151,87 +145,29 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
 }
 
 @suite class Id3v2_UserUrlLinkFrame_PropertyTests {
-    @test
-    public getDescription_emptyText_returnsUndefined() {
+    @params(undefined, "undefined")
+    @params(null, "null")
+    @params("", "empty_string")
+    @params("fux", "truthy")
+    public setDescription(value: string) {
         // Arrange
-        const frame = UserUrlLinkFrame.fromDescription(undefined);
+        const frame = UserUrlLinkFrame.fromFields("foo", "bar");
 
         // Act
-        const result = frame.description;
+        frame.description = value;
 
         // Assert
-        assert.isUndefined(result);
-    }
-
-    @test
-    public setDescription_existingDescription_undefined() {
-        // Arrange
-        const frame = getTestUserUrlLinkFrame();
-
-        // Act
-        frame.description = undefined;
-
-        // Assert
-        assert.isUndefined(frame.description);
+        assert.strictEqual(frame.description, value);
         assert.strictEqual(frame.text, "bar");
     }
 
-    @test
-    public setDescription_existingDescription_value() {
+    @params(undefined, "undefined")
+    @params(null, "null")
+    @params("", "empty_string")
+    @params("bux", "truthy")
+    public setText(value: string) {
         // Arrange
-        const frame = getTestUserUrlLinkFrame();
-
-        // Act
-        frame.description = "fux";
-
-        // Assert
-        assert.strictEqual(frame.description, "fux");
-        assert.strictEqual(frame.text, "bar");
-    }
-
-    @test
-    public setDescription_noDescription_value() {
-        // Arrange
-        const frame = UserUrlLinkFrame.fromDescription(undefined);
-
-        // Act
-        frame.description = "fux";
-
-        // Assert
-        assert.strictEqual(frame.description, "fux");
-    }
-
-    @test
-    public setText_undefined() {
-        // Arrange
-        const frame = getTestUserUrlLinkFrame();
-
-        // Act
-        frame.text = undefined;
-
-        // Assert
-        assert.strictEqual(frame.description, "foo");
-        assert.strictEqual(frame.text, "");
-    }
-
-    @test
-    public setText_null() {
-        // Arrange
-        const frame = getTestUserUrlLinkFrame();
-
-        // Act
-        frame.text = null;
-
-        // Assert
-        assert.strictEqual(frame.description, "foo");
-        assert.strictEqual(frame.text, "");
-    }
-
-    @test
-    public setText_values() {
-        // Arrange
-        const frame = getTestUserUrlLinkFrame();
-        const value = "fux";
+        const frame = UserUrlLinkFrame.fromFields("foo", "bar");
 
         // Act
         frame.text = value;
@@ -244,7 +180,7 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
     @test
     public setEncoding() {
         // Arrange
-        const frame = getTestUserUrlLinkFrame();
+        const frame = UserUrlLinkFrame.fromFields("foo", "bar");
 
         // Act
         frame.textEncoding = StringType.UTF8;
@@ -264,7 +200,7 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
     @test
     public findUserUrlLinkFrame_falsyIdentity_throws(): void {
         // Arrange
-        const frames = [getTestUserUrlLinkFrame()];
+        const frames = [UserUrlLinkFrame.fromFields("foo", "bar")];
 
         // Act/Assert
         Testers.testTruthy((v: string) => { UserUrlLinkFrame.findUserUrlLinkFrame(frames, v); });
@@ -285,10 +221,13 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
     @test
     public findUserUrlLinkFrame_noMatch_returnsUndefined() {
         // Arrange
-        const frames = [getTestUserUrlLinkFrame(), getTestUserUrlLinkFrame()];
+        const frames = [
+            UserUrlLinkFrame.fromFields("foo", "fux"),
+            UserUrlLinkFrame.fromFields("bar", "bux")
+        ];
 
         // Act
-        const result = UserUrlLinkFrame.findUserUrlLinkFrame(frames, "bar");
+        const result = UserUrlLinkFrame.findUserUrlLinkFrame(frames, "baz");
 
         // Assert
         assert.isUndefined(result);
@@ -297,8 +236,8 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
     @test
     public findUserUrlLinkFrame_match_returnsFirstMatch() {
         // Arrange
-        const frame1 = getTestUserUrlLinkFrame();
-        const frame2 = getTestUserUrlLinkFrame();
+        const frame1 = UserUrlLinkFrame.fromFields("foo", "bar");
+        const frame2 = UserUrlLinkFrame.fromFields("foo", "bux");
         const frames = [frame1, frame2];
 
         // Act
@@ -309,9 +248,10 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
     }
 
     @test
-    public clone_withRawData_returnsCloneUsingRawData() {
+    public clone_returnsClone() {
         // Arrange
-        const frame = getTestUserUrlLinkFrame();
+        const frame = UserUrlLinkFrame.fromFields("foo", "fux");
+        frame.textEncoding = StringType.UTF16BE;
 
         // Act
         const result = frame.clone();
@@ -325,44 +265,128 @@ const getTestUserUrlLinkFrame = (): UserUrlLinkFrame => {
     }
 
     @test
-    public clone_withoutRawData_returnsClone() {
+    public render_withoutDescriptionWithoutText() {
         // Arrange
-        const frame = getTestUserUrlLinkFrame();
-        // noinspection JSUnusedLocalSymbols Forces a read of the raw data
-        const _ = frame.text;
-
-        // Act
-        const result = frame.clone();
-
-        // Assert
-        assert.isOk(result);
-        assert.strictEqual(result.frameId, frame.frameId);
-        assert.strictEqual(result.description, frame.description);
-        assert.strictEqual(result.text, frame.text);
-        assert.strictEqual(result.textEncoding, frame.textEncoding);
-    }
-
-    @test
-    public render_returnsByteVector() {
-        // Arrange
-        const frame = getTestUserUrlLinkFrame();
+        const frame = UserUrlLinkFrame.fromFields(undefined, undefined);
+        frame.textEncoding = StringType.Latin1;
 
         // Act
         const result = frame.render(4);
 
         // Assert
         assert.isOk(result);
-        Testers.bvEqual(result, getTestFrameData());
+
+        const expectedBytes = ByteVector.concatenate(
+            FrameIdentifiers.WXXX.render(4),
+            ByteVector.fromUint(2),
+            ByteVector.fromUshort(Id3v2FrameFlags.None),
+            ByteVector.fromByte(StringType.Latin1),
+            ByteVector.getTextDelimiter(StringType.Latin1)
+        );
+        Testers.bvEqual(result, expectedBytes);
     }
 
-    @params(["", ""], "empty string")
-    @params(["foo", ""], "foo+empty string")
-    @params(["", "foo"], "empty string+foo")
-    @params(["foo", "bar"], "foo+bar")
+    @test
+    public render_withoutDescriptionWithText() {
+        // Arrange
+        const frame = UserUrlLinkFrame.fromFields(undefined, "foo");
+        frame.textEncoding = StringType.Latin1;
+
+        // Act
+        const result = frame.render(4);
+
+        // Assert
+        assert.isOk(result);
+
+        const expectedBytes = ByteVector.concatenate(
+            FrameIdentifiers.WXXX.render(4),
+            ByteVector.fromUint(5),
+            ByteVector.fromUshort(Id3v2FrameFlags.None),
+            ByteVector.fromByte(StringType.Latin1),
+            ByteVector.getTextDelimiter(StringType.Latin1),
+            ByteVector.fromString("foo", StringType.Latin1)
+        );
+        Testers.bvEqual(result, expectedBytes);
+    }
+
+    @test
+    public render_withDescriptionWithoutText() {
+        // Arrange
+        const frame = UserUrlLinkFrame.fromFields("foo", undefined);
+        frame.textEncoding = StringType.Latin1;
+
+        // Act
+        const result = frame.render(4);
+
+        // Assert
+        assert.isOk(result);
+
+        const expectedBytes = ByteVector.concatenate(
+            FrameIdentifiers.WXXX.render(4),
+            ByteVector.fromUint(5),
+            ByteVector.fromUshort(Id3v2FrameFlags.None),
+            ByteVector.fromByte(StringType.Latin1),
+            ByteVector.fromString("foo", StringType.Latin1),
+            ByteVector.getTextDelimiter(StringType.Latin1)
+        );
+        Testers.bvEqual(result, expectedBytes);
+    }
+
+    @test
+    public render_withDescriptionWithText() {
+        // Arrange
+        const frame = UserUrlLinkFrame.fromFields("foo", "bar");
+        frame.textEncoding = StringType.Latin1;
+
+        // Act
+        const result = frame.render(4);
+
+        // Assert
+        assert.isOk(result);
+
+        const expectedBytes = ByteVector.concatenate(
+            FrameIdentifiers.WXXX.render(4),
+            ByteVector.fromUint(8),
+            ByteVector.fromUshort(Id3v2FrameFlags.None),
+            ByteVector.fromByte(StringType.Latin1),
+            ByteVector.fromString("foo", StringType.Latin1),
+            ByteVector.getTextDelimiter(StringType.Latin1),
+            ByteVector.fromString("bar", StringType.Latin1)
+        );
+        Testers.bvEqual(result, expectedBytes);
+    }
+
+    @test
+    public render_withDescriptionWithText_twoByteEncoding() {
+        // Arrange
+        const frame = UserUrlLinkFrame.fromFields("foo", "bar");
+        frame.textEncoding = StringType.UTF16LE
+
+        // Act
+        const result = frame.render(4);
+
+        // Assert
+        assert.isOk(result);
+
+        const expectedBytes = ByteVector.concatenate(
+            FrameIdentifiers.WXXX.render(4),
+            ByteVector.fromUint(12),
+            ByteVector.fromUshort(Id3v2FrameFlags.None),
+            ByteVector.fromByte(StringType.UTF16LE),
+            ByteVector.fromString("foo", StringType.UTF16LE),
+            ByteVector.getTextDelimiter(StringType.UTF16LE),
+            ByteVector.fromString("bar", StringType.Latin1)
+        );
+        Testers.bvEqual(result, expectedBytes);
+    }
+
+    @params(["", ""], "empty_string")
+    @params(["foo", ""], "foo_empty_string")
+    @params(["", "foo"], "empty_string_foo")
+    @params(["foo", "bar"], "foo_bar")
     public toString_returnsText([description, text]: [string, string]) {
         // Arrange
-        const frame = UserUrlLinkFrame.fromDescription(description);
-        frame.text = text;
+        const frame = UserUrlLinkFrame.fromFields(description, text);
 
         // Act
         const result = frame.toString();

--- a/test-unit/id3v2/userUrlLinkFrameTests.ts
+++ b/test-unit/id3v2/userUrlLinkFrameTests.ts
@@ -142,6 +142,34 @@ import {UserUrlLinkFrame} from "../../src/id3v2/frames/urlLinkFrame";
         assert.strictEqual(output.text, "foo");
         assert.strictEqual(output.textEncoding, StringType.UTF16BE);
     }
+
+    @test
+    public fromOffsetRawData_illFormedThreeFields() {
+        // Arrange
+        const bodyBytes = ByteVector.concatenate(
+            StringType.UTF16BE,
+            ByteVector.fromString("foo", StringType.UTF16BE), // Description
+            ByteVector.getTextDelimiter(StringType.UTF16BE),  // Description delimiter
+            ByteVector.fromString("bar", StringType.Latin1),  // Text
+            ByteVector.getTextDelimiter(StringType.Latin1),   // Bogus
+            ByteVector.fromString("baz", StringType.Latin1),  // Bogus
+            ByteVector.getTextDelimiter(StringType.Latin1),   // Bogus
+        );
+        const header = new Id3v2FrameHeader(FrameIdentifiers.WXXX, Id3v2FrameFlags.None, bodyBytes.length);
+        const data = ByteVector.concatenate(header.render(4), bodyBytes);
+
+        // Act
+        const output = UserUrlLinkFrame.fromOffsetRawData(data, 0, header, 4);
+
+        // Assert
+        assert.ok(output);
+        assert.equal(output.frameClassType, FrameClassType.UserUrlLinkFrame);
+        assert.strictEqual(output.frameId, FrameIdentifiers.WXXX);
+
+        assert.strictEqual(output.description, "foo");
+        assert.strictEqual(output.text, "bar");
+        assert.strictEqual(output.textEncoding, StringType.UTF16BE);
+    }
 }
 
 @suite class Id3v2_UserUrlLinkFrame_PropertyTests {
@@ -275,15 +303,7 @@ import {UserUrlLinkFrame} from "../../src/id3v2/frames/urlLinkFrame";
 
         // Assert
         assert.isOk(result);
-
-        const expectedBytes = ByteVector.concatenate(
-            FrameIdentifiers.WXXX.render(4),
-            ByteVector.fromUint(2),
-            ByteVector.fromUshort(Id3v2FrameFlags.None),
-            ByteVector.fromByte(StringType.Latin1),
-            ByteVector.getTextDelimiter(StringType.Latin1)
-        );
-        Testers.bvEqual(result, expectedBytes);
+        assert.strictEqual(result.length, 0);
     }
 
     @test


### PR DESCRIPTION
* Drop lazy loading from UrlLinkFrame and UserUrlLinkFrame
* There's no text encoding for a UrlLinkFrame, move it out to UserUrlLinkFrame
* Make UrlLinkFrame store a single text frame
* Fix broken rendering of WXXX frames

This is a breaking change in that it removes W*** frame support from Id3v2Tag.setTextFrame, but introduces Id3v2Tag.setUrlFrame as an alternative.

New tests were added! 100% coverage of urlLinkFrame.ts