### PR TITLE
[ID3v2] TCON Frame

### DIFF
--- a/src/id3v2/frames/frame.ts
+++ b/src/id3v2/frames/frame.ts
@@ -27,6 +27,11 @@ export enum FrameClassType {
     EventTimeCodeFrame,
 
     /**
+     * Indicates the frame is a genre frame.
+     */
+    GenreFrame,
+
+    /**
      * Indicates the frame is a music CD identifier frame.
      */
     MusicCdIdentifierFrame,
@@ -94,7 +99,7 @@ export enum FrameClassType {
     /**
      * Indicates the frame is a user URL link frame.
      */
-    UserUrlLinkFrame
+    UserUrlLinkFrame,
 }
 
 /**

--- a/src/id3v2/frames/frameFactory.ts
+++ b/src/id3v2/frames/frameFactory.ts
@@ -1,5 +1,6 @@
 import AttachmentFrame from "./attachmentFrame";
 import CommentsFrame from "./commentsFrame";
+import GenreFrame from "./genreFrame";
 import MusicCdIdentifierFrame from "./musicCdIdentifierFrame";
 import PlayCountFrame from "./playCountFrame";
 import PopularimeterFrame from "./popularimeterFrame";
@@ -176,7 +177,10 @@ export class Id3v2FrameFactory {
             }
 
             let func: FrameCreator;
-            if (header.frameId === FrameIdentifiers.TXXX) {
+            if (header.frameId === FrameIdentifiers.TCON) {
+                // Content type frame
+                func = GenreFrame.fromOffsetRawData;
+            } else if (header.frameId === FrameIdentifiers.TXXX) {
                 // User text identification frame
                 func = UserTextInformationFrame.fromOffsetRawData;
             } else if (header.frameId.isTextFrame) {

--- a/src/id3v2/frames/genreFrame.ts
+++ b/src/id3v2/frames/genreFrame.ts
@@ -4,7 +4,7 @@ import {ByteVector, StringType} from "../../byteVector";
 import {Frame, FrameClassType} from "./frame";
 import {Id3v2FrameHeader} from "./frameHeader";
 import {FrameIdentifiers} from "../frameIdentifiers";
-import {Guards} from "../../utils";
+import {Guards, StringUtils} from "../../utils";
 
 /**
  * This class provides support for ID3v2 TCON content type frames.
@@ -129,28 +129,32 @@ export default class GenreFrame extends Frame {
         this._encoding = data.get(0);
 
         const fieldList = [];
-        const delim = ByteVector.getTextDelimiter(this._encoding);
-
         if (version > 3) {
             // TCON on ID3v2.4 is encoded as a separate field for each genre. Fields can either be
             // the old numeric ID3v1 genres (no parenthesis) or free text. RX/CR can also be used.
             const genres = data.subarray(1).toStrings(this._encoding);
-            const textGenres = genres.map((g) => {
-                switch (g) {
-                    case GenreFrame.COVER_ABBREV:
-                        return GenreFrame.COVER_STRING;
-                    case GenreFrame.REMIX_ABBREV:
-                        return GenreFrame.REMIX_STRING;
-                    default:
-                        const textGenre = Genres.indexToAudio(g, false);
-                        return textGenre || g;
-                }
-            });
+            const textGenres = genres
+                .map(g => {
+                    // Trim trailing whitespace and null bytes
+                    g = StringUtils.trimEnd(g, " \t\r\n\0");
+
+                    // Parse special cases or fallback to just returning the value
+                    switch (g) {
+                        case GenreFrame.COVER_ABBREV:
+                            return GenreFrame.COVER_STRING;
+                        case GenreFrame.REMIX_ABBREV:
+                            return GenreFrame.REMIX_STRING;
+                        default:
+                            const textGenre = Genres.indexToAudio(g, false);
+                            return textGenre || g;
+                    }
+                })
+                .filter(g => !!g);
             fieldList.push(...textGenres);
-        } else if (data.length > 1 && !data.containsAt(delim, 1)) {
+        } else {
             let value = data.subarray(1).toString(this._encoding);
 
-            // Truncate values containing NULL bytes
+            // Truncate values containing NULL bytes (ie, ignore everything after a null byte)
             const nullIndex = value.indexOf("\x00");
             if (nullIndex >= 0) {
                 value = value.substring(0, nullIndex);
@@ -188,13 +192,6 @@ export default class GenreFrame extends Frame {
                 // Yeah, we can't do anything smart, just treat it as a string
                 fieldList.push(term);
             }
-        }
-
-        // Bad tags may have one or more null characters at the end of a string, resulting in
-        // empty strings at the end of the FieldList. Strip them off.
-        while (fieldList.length !== 0
-            && (!fieldList[fieldList.length - 1] || fieldList[fieldList.length - 1].length === 0)) {
-            fieldList.splice(fieldList.length - 1, 1);
         }
 
         this._textFields = fieldList;

--- a/src/id3v2/frames/genreFrame.ts
+++ b/src/id3v2/frames/genreFrame.ts
@@ -1,0 +1,377 @@
+import Genres from "../../genres";
+import Id3v2Settings from "../id3v2Settings";
+import {ByteVector, StringType} from "../../byteVector";
+import {Frame, FrameClassType} from "./frame";
+import {Id3v2FrameHeader} from "./frameHeader";
+import {FrameIdentifiers} from "../frameIdentifiers";
+import {Guards} from "../../utils";
+
+/**
+ * This class provides support for ID3v2 TCON content type frames.
+ */
+export default class GenreFrame extends Frame {
+    private static readonly COVER_ABBREV = "CR";
+    private static readonly COVER_STRING = "Cover";
+    private static readonly REMIX_ABBREV = "RX";
+    private static readonly REMIX_STRING = "Remix";
+
+    private _encoding: StringType = Id3v2Settings.defaultEncoding;
+    private _textFields: string[] = [];
+
+    // #region Constructors
+
+    private constructor(header: Id3v2FrameHeader) {
+        super(header);
+    }
+
+    /**
+     * Constructs and initializes a new instance.
+     * @param encoding Optionally, the encoding to use for the new instance. If omitted, defaults
+     *     to {@link Id3v2Settings.defaultEncoding}
+     */
+    public static fromEncoding(
+        encoding: StringType = Id3v2Settings.defaultEncoding
+    ): GenreFrame {
+        const frame = new GenreFrame(new Id3v2FrameHeader(FrameIdentifiers.TCON));
+        frame._encoding = encoding;
+        return frame;
+    }
+
+    /**
+     * Constructs and initializes a new instance by reading its raw data in a specified ID3v2
+     * version. This method allows for offset reading from the data byte vector.
+     * @param data Raw representation of the new frame
+     * @param offset What offset in `data` the frame actually begins. Must be positive,
+     *     safe integer
+     * @param header Header of the frame found at `data` in the data
+     * @param version ID3v2 version the frame was originally encoded with
+     */
+    public static fromOffsetRawData(
+        data: ByteVector,
+        offset: number,
+        header: Id3v2FrameHeader,
+        version: number
+    ): GenreFrame {
+        Guards.truthy(data, "data");
+        Guards.uint(offset, "offset");
+        Guards.truthy(header, "header");
+        Guards.byte(version, "version");
+
+        const frame = new GenreFrame(header);
+        frame.setData(data, offset, false, version);
+        return frame;
+    }
+
+    // #endregion
+
+    // #region Properties
+
+    /** @inheritDoc */
+    public get frameClassType(): FrameClassType { return FrameClassType.GenreFrame; }
+
+    /**
+     * Gets the genres contained in the current instance.
+     * Note: Modifying the contents of the returned value will not modify the contents of the
+     * current instance. The value must be reassigned for the value to change.
+     */
+    public get text(): string[] { return this._textFields.slice(); }
+    /**
+     * Sets the genres contained in the current instance.
+     */
+    public set text(value: string[]) { this._textFields = value ? value.slice() : []; }
+
+    /**
+     * Gets the text encoding to use when rendering the current instance.
+     */
+    public get textEncoding(): StringType { return this._encoding; }
+    /**
+     * Sets the text encoding to use when rendering the current instance.
+     * This value will be overridden if {@link Id3v2Settings.forceDefaultEncoding} is `true`.
+     */
+    public set textEncoding(value: StringType) { this._encoding = value; }
+
+    // #endregion
+
+    // #region Public Methods
+
+    /**
+     * Gets a {@link GenreFrame} object from a specified list of genre frames.
+     * @param frames List of frames to search
+     * @returns Matching frame if it exists in `tag`, `undefined` if a matching frame was not found
+     */
+    public static findGenreFrame(frames: GenreFrame[]): GenreFrame {
+        Guards.truthy(frames, "frames");
+
+        return frames.find((f) => f.frameId === FrameIdentifiers.TCON);
+    }
+
+    /** @inheritDoc */
+    public clone(): Frame {
+        const frame = GenreFrame.fromEncoding(this._encoding);
+        frame._textFields = this._textFields.slice();
+        return frame;
+    }
+
+    /**
+     * Returns a text representation of the current instance by combining the genres with semicolons.
+     */
+    public toString(): string {
+        return this.text.join("; ");
+    }
+
+    // #endregion
+
+    // #region Protected Methods
+
+    /** @inheritDoc */
+    protected parseFields(data: ByteVector, version: number): void {
+        // Read the string data type (first byte of the field data)
+        this._encoding = data.get(0);
+
+        const fieldList = [];
+        const delim = ByteVector.getTextDelimiter(this._encoding);
+
+        if (version > 3) {
+            // TCON on ID3v2.4 is encoded as a separate field for each genre. Fields can either be
+            // the old numeric ID3v1 genres (no parenthesis) or free text. RX/CR can also be used.
+            const genres = data.subarray(1).toStrings(this._encoding);
+            const textGenres = genres.map((g) => {
+                switch (g) {
+                    case GenreFrame.COVER_ABBREV:
+                        return GenreFrame.COVER_STRING;
+                    case GenreFrame.REMIX_ABBREV:
+                        return GenreFrame.REMIX_STRING;
+                    default:
+                        const textGenre = Genres.indexToAudio(g, false);
+                        return textGenre || g;
+                }
+            });
+            fieldList.push(...textGenres);
+        } else if (data.length > 1 && !data.containsAt(delim, 1)) {
+            let value = data.subarray(1).toString(this._encoding);
+
+            // Truncate values containing NULL bytes
+            const nullIndex = value.indexOf("\x00");
+            if (nullIndex >= 0) {
+                value = value.substring(0, nullIndex);
+            }
+
+            // TCON in ID3v2.2 and ID3v2.3 is specified as
+            // * (xx) - where xx is a number from the ID3v1 genre list
+            // * (xx)yy - where xx is a number from the ID3v1 genre list and yyy is a
+            //   "refinement" of the genre
+            // * (RX) - "Remix"
+            // * (CR) - "Cover"
+            // * (( - used to escape a "(" in a refinement/genre name
+
+            // Treat each term separately
+            const terms = Id3v2Settings.useNonStandardV2V3GenreSeparators
+                ? value.split(/[;\/]/).filter(t => !!t)
+                : [value];
+            for (const term of terms) {
+                // Attempt to process it according to our best understanding of the spec
+                const numericGenres = this.parseTconAsStandardNumeric(term);
+                if (numericGenres !== undefined) {
+                    fieldList.push(... numericGenres);
+                    continue;
+                }
+
+                if (Id3v2Settings.useNonStandardV2V3NumericGenres) {
+                    // Attempt to process it as a non-standard numeric genre
+                    const numericGenre = Genres.indexToAudioDirect(term);
+                    if (numericGenre !== undefined) {
+                        fieldList.push(numericGenre);
+                        continue;
+                    }
+                }
+
+                // Yeah, we can't do anything smart, just treat it as a string
+                fieldList.push(term);
+            }
+        }
+
+        // Bad tags may have one or more null characters at the end of a string, resulting in
+        // empty strings at the end of the FieldList. Strip them off.
+        while (fieldList.length !== 0
+            && (!fieldList[fieldList.length - 1] || fieldList[fieldList.length - 1].length === 0)) {
+            fieldList.splice(fieldList.length - 1, 1);
+        }
+
+        this._textFields = fieldList;
+    }
+
+    /** @inheritDoc */
+    protected renderFields(version: number): ByteVector {
+        const encoding = GenreFrame.correctEncoding(this.textEncoding, version);
+        const v = ByteVector.empty();
+        let text = this._textFields;
+
+        v.addByte(encoding);
+
+        if (version > 3) {
+            // For ID3v2.4, we should encode any genres that can be numeric as numeric by
+            // themselves. This then gets encoded the same as any other ID3v2.4 text frame (ie,
+            // with delimiters in between values)
+            text = text.map((g) => {
+                switch (g) {
+                    case GenreFrame.COVER_STRING:
+                        return GenreFrame.COVER_ABBREV;
+                    case GenreFrame.REMIX_STRING:
+                        return GenreFrame.REMIX_ABBREV;
+                    default:
+                        if (Id3v2Settings.useNumericGenres) {
+                            const numericGenre = Genres.audioToIndex(g);
+                            return numericGenre === 255 ? g : numericGenre.toString();
+                        }
+                        return g;
+                }
+            });
+
+            for (let i = 0; i < text.length; i++) {
+                // Since the field list is null delimited, if this is not the first element in the
+                // list, append the appropriate delimiter for this encoding.
+                if (i !== 0) {
+                    v.addByteVector(ByteVector.getTextDelimiter(encoding));
+                }
+
+                if (text[i]) {
+                    v.addByteVector(ByteVector.fromString(text[i], encoding));
+                }
+            }
+        } else {
+            // ID3v2.2 and ID3v2.3 TCON frames are going to be written with numeric genres first
+            // (if enabled) and multiple text-based genres separated by ;.
+            // NOTE: This doesn't follow the actual conventions for ID3v2.2/3 but nobody does this
+            //    correctly. This implementation will at least work with MinimServer
+            //    https://forum.minimserver.com/showthread.php?tid=2575
+            const numericGenres = [];
+            const textGenres = [];
+            for (const s of text) {
+                if (Id3v2Settings.useNumericGenres) {
+                    // Try to process it as a numeric genre
+                    switch (s) {
+                        case GenreFrame.COVER_STRING:
+                            numericGenres.push(`(${GenreFrame.COVER_ABBREV})`);
+                            continue;
+                        case GenreFrame.REMIX_STRING:
+                            numericGenres.push(`(${GenreFrame.REMIX_ABBREV})`);
+                            continue;
+                        default:
+                            const numericGenre = Genres.audioToIndex(s);
+                            if (numericGenre !== 255) {
+                                numericGenres.push(`(${numericGenre})`);
+                                continue;
+                            }
+                            break;
+                    }
+                }
+
+                // Process it as a text genre
+                const escapedGenre = s.replace(/\(/g, "((");
+                textGenres.push(escapedGenre);
+            }
+
+            // Put the entire string together
+            const genreString = `${numericGenres.join("")}${textGenres.join(";")}`;
+            v.addByteVector(ByteVector.fromString(genreString, encoding));
+        }
+
+        return v;
+    }
+
+    // #endregion
+
+    private parseTconAsStandardNumeric(field: string): string[]|undefined {
+        // Don't even bother setting up the state machine if we aren't starting with an opening
+        // parenthesis.
+        if (field[0] !== "(") {
+            return undefined;
+        }
+
+        const results: string[] = [];
+        let inParentheses = true;
+        let refinementAdded = false;
+        let open = 0;
+        let close = 0;
+
+        const appendToLastResult = (chunk: string): void => {
+            if (!chunk) {
+                return;
+            }
+
+            const lastResult = results[results.length - 1];
+            results[results.length - 1] = refinementAdded
+                ? `${lastResult}${chunk}`
+                : `${lastResult} ${chunk}`;
+        };
+
+        for (let i = 1; i < field.length; i++) {
+            if (inParentheses) {
+                // Inside parentheses ----------------------------------
+                if (field[i] === ")") {
+                    // Closing parenthesis found
+                    close = i;
+
+                    // Attempt to parse the inside as a number
+                    const parenContents = field.substring(open + 1, close);
+                    const numericGenre = Genres.indexToAudioDirect(parenContents);
+                    if (numericGenre !== undefined) {
+                        results.push(numericGenre);
+                    } else if (parenContents === GenreFrame.COVER_ABBREV) {
+                        results.push(GenreFrame.COVER_STRING);
+                    } else if (parenContents === GenreFrame.REMIX_ABBREV) {
+                        results.push(GenreFrame.REMIX_STRING);
+                    } else {
+                        // What we expected to be a numeric genre was not. We will assume this
+                        // field is not using standard numeric genres, and dump the remainder.
+                        break;
+                    }
+
+                    // Transition to refinement processing
+                    inParentheses = false;
+                    refinementAdded = false;
+                    open = i + 1;
+                }
+
+                // If we didn't find the closing paren, just increment and try again.
+            } else {
+                // Processing refinement  ------------------------------
+                let refinementChunk: string;
+                if (field[i] === "(") {
+                    if (field[i + 1] === "(") {
+                        // This is an escape sequence
+                        // Take the current refinement chunk + the first paren (eg: `xyz(`)
+                        refinementChunk = field.substring(open, i + 1);
+
+                        // Skip over the next character (ie, `(`)
+                        open = i + 2;
+                        i++;
+                    } else {
+                        // This is possibly the start of a numeric genre.
+                        // Take the current refinement chunk
+                        refinementChunk = field.substring(open, i);
+
+                        // Transition back to numeric genre processing.
+                        inParentheses = true;
+                        open = i;
+                    }
+
+                    // Add the refinement chunk to the last result
+                    appendToLastResult(refinementChunk);
+                    refinementAdded = true;
+                }
+
+                // If we didn't find an opening paren, just increment and try again
+            }
+        }
+
+        // Process the remainder
+        // If we didn't find any results, then just return undefined.
+        if (results.length === 0) {
+            return undefined;
+        }
+
+        appendToLastResult(field.substring(open));
+        return results;
+    }
+}

--- a/src/id3v2/frames/textInformationFrame.ts
+++ b/src/id3v2/frames/textInformationFrame.ts
@@ -1,4 +1,3 @@
-import Genres from "../../genres";
 import Id3v2Settings from "../id3v2Settings";
 import {ByteVector, StringType} from "../../byteVector";
 import {Frame, FrameClassType} from "./frame";
@@ -128,10 +127,6 @@ import {Guards, StringComparison} from "../../utils";
  *   (TIT2) for sorting purposes.
  */
 export class TextInformationFrame extends Frame {
-    private static readonly COVER_ABBREV = "CR";
-    private static readonly COVER_STRING = "Cover";
-    private static readonly REMIX_ABBREV = "RX";
-    private static readonly REMIX_STRING = "Remix";
     private static readonly SPLIT_FRAME_TYPES = [
         FrameIdentifiers.TCOM,
         FrameIdentifiers.TEXT,
@@ -363,24 +358,7 @@ export class TextInformationFrame extends Frame {
         const fieldList = [];
         const delim = ByteVector.getTextDelimiter(this._encoding);
 
-        if (this._rawVersion > 3 && this.frameId === FrameIdentifiers.TCON) {
-            // TCON on ID3v2.4 is encoded as a separate field for each genre. Fields can either be
-            // the old numeric ID3v1 genres (no parenthesis) or free text. RX/CR can also be used.
-            // This way is **much** better...
-            const genres = data.subarray(1).toStrings(this._encoding);
-            const textGenres = genres.map((g) => {
-                switch (g) {
-                    case TextInformationFrame.COVER_ABBREV:
-                        return TextInformationFrame.COVER_STRING;
-                    case TextInformationFrame.REMIX_ABBREV:
-                        return TextInformationFrame.REMIX_STRING;
-                    default:
-                        const textGenre = Genres.indexToAudio(g, false);
-                        return textGenre || g;
-                }
-            });
-            fieldList.push(...textGenres);
-        } else if (this._rawVersion > 3 || this.frameId === FrameIdentifiers.TXXX) {
+        if (this._rawVersion > 3 || this.frameId === FrameIdentifiers.TXXX) {
             fieldList.push(...data.subarray(1).toStrings(this._encoding));
         } else if (data.length > 1 && !data.containsAt(delim, 1)) {
             let value = data.subarray(1).toString(this._encoding);
@@ -394,40 +372,6 @@ export class TextInformationFrame extends Frame {
             if (TextInformationFrame.SPLIT_FRAME_TYPES.some((ft) => ft === this.frameId)) {
                 // Some frames are designed to be split into multiple parts by a /
                 fieldList.push(... value.split("/"));
-            } else if (this.frameId === FrameIdentifiers.TCON) {
-                // @TODO: Can we just make a separate class for TCON?
-                // TCON in ID3v2.2 and ID3v2.3 is specified as
-                // * (xx) - where xx is a number from the ID3v1 genre list
-                // * (xx)yy - where xx is a number from the ID3v1 genre list and yyy is a
-                //   "refinement" of the genre
-                // * (RX) - "Remix"
-                // * (CR) - "Cover"
-                // * (( - used to escape a "(" in a refinement/genre name
-
-                // Treat each term separately
-                const terms = Id3v2Settings.useNonStandardV2V3GenreSeparators
-                    ? value.split(/[;\/]/).filter(t => !!t)
-                    : [value];
-                for (const term of terms) {
-                    // Attempt to process it according to our best understanding of the spec
-                    const numericGenres = this.parseTconAsStandardNumeric(term);
-                    if (numericGenres !== undefined) {
-                        fieldList.push(... numericGenres);
-                        continue;
-                    }
-
-                    if (Id3v2Settings.useNonStandardV2V3NumericGenres) {
-                        // Attempt to process it as a non-standard numeric genre
-                        const numericGenre = Genres.indexToAudioDirect(term);
-                        if (numericGenre !== undefined) {
-                            fieldList.push(numericGenre);
-                            continue;
-                        }
-                    }
-
-                    // Yeah, we can't do anything smart, just treat it as a string
-                    fieldList.push(term);
-                }
             } else {
                 fieldList.push(value);
             }
@@ -455,27 +399,6 @@ export class TextInformationFrame extends Frame {
 
         v.addByte(encoding);
 
-        // Pre-process ID3v2.4 TCON frames
-        if (version > 3 && this.frameId === FrameIdentifiers.TCON) {
-            // For ID3v2.4, we should encode any genres that can be numeric as numeric by
-            // themselves. This then gets encoded the same as any other ID3v2.4 text frame (ie,
-            // with delimiters in between values)
-            text = text.map((g) => {
-                switch (g) {
-                    case TextInformationFrame.COVER_STRING:
-                        return TextInformationFrame.COVER_ABBREV;
-                    case TextInformationFrame.REMIX_STRING:
-                        return TextInformationFrame.REMIX_ABBREV;
-                    default:
-                        if (Id3v2Settings.useNumericGenres) {
-                            const numericGenre = Genres.audioToIndex(g);
-                            return numericGenre === 255 ? g : numericGenre.toString();
-                        }
-                        return g;
-                }
-            });
-        }
-
         // Main processing
         const isTxxx = this.frameId === FrameIdentifiers.TXXX;
         if (version > 3 || isTxxx) {
@@ -498,42 +421,6 @@ export class TextInformationFrame extends Frame {
                     v.addByteVector(ByteVector.fromString(text[i], encoding));
                 }
             }
-        } else if (this.frameId === FrameIdentifiers.TCON) {
-            // ID3v2.2 and ID3v2.3 TCON frames are going to be written with numeric genres first
-            // (if enabled) and multiple text-based genres separated by ;.
-            // NOTE: This doesn't follow the actual conventions for ID3v2.2/3 but nobody does this
-            //    correctly. This implementation will at least work with MinimServer
-            //    https://forum.minimserver.com/showthread.php?tid=2575
-            const numericGenres = [];
-            const textGenres = [];
-            for (const s of text) {
-                if (Id3v2Settings.useNumericGenres) {
-                    // Try to process it as a numeric genre
-                    switch (s) {
-                        case TextInformationFrame.COVER_STRING:
-                            numericGenres.push(`(${TextInformationFrame.COVER_ABBREV})`);
-                            continue;
-                        case TextInformationFrame.REMIX_STRING:
-                            numericGenres.push(`(${TextInformationFrame.REMIX_ABBREV})`);
-                            continue;
-                        default:
-                            const numericGenre = Genres.audioToIndex(s);
-                            if (numericGenre !== 255) {
-                                numericGenres.push(`(${numericGenre})`);
-                                continue;
-                            }
-                            break;
-                    }
-                }
-
-                // Process it as a text genre
-                const escapedGenre = s.replace(/\(/g, "((");
-                textGenres.push(escapedGenre);
-            }
-
-            // Put the entire string together
-            const genreString = `${numericGenres.join("")}${textGenres.join(";")}`;
-            v.addByteVector(ByteVector.fromString(genreString, encoding));
         } else {
             // Fields that have slashes in them and fields that don't
             v.addByteVector(ByteVector.fromString(text.join("/"), encoding));
@@ -543,101 +430,6 @@ export class TextInformationFrame extends Frame {
     }
 
     // #endregion
-
-    private parseTconAsStandardNumeric(field: string): string[]|undefined {
-        // Don't even bother setting up the state machine if we aren't starting with an opening
-        // parenthesis.
-        if (field[0] !== "(") {
-            return undefined;
-        }
-
-        const results: string[] = [];
-        let inParentheses = true;
-        let refinementAdded = false;
-        let open = 0;
-        let close = 0;
-
-        const appendToLastResult = (chunk: string): void => {
-            if (!chunk) {
-                return;
-            }
-
-            const lastResult = results[results.length - 1];
-            results[results.length - 1] = refinementAdded
-                ? `${lastResult}${chunk}`
-                : `${lastResult} ${chunk}`;
-        }
-
-        for (let i = 1; i < field.length; i++) {
-            if (inParentheses) {
-                // Inside parentheses ----------------------------------
-                if (field[i] === ")") {
-                    // Closing parenthesis found
-                    close = i;
-
-                    // Attempt to parse the inside as a number
-                    const parenContents = field.substring(open + 1, close);
-                    const numericGenre = Genres.indexToAudioDirect(parenContents);
-                    if (numericGenre !== undefined) {
-                        results.push(numericGenre);
-                    } else if (parenContents === TextInformationFrame.COVER_ABBREV) {
-                        results.push(TextInformationFrame.COVER_STRING);
-                    } else if (parenContents === TextInformationFrame.REMIX_ABBREV) {
-                        results.push(TextInformationFrame.REMIX_STRING);
-                    } else {
-                        // What we expected to be a numeric genre was not. We will assume this
-                        // field is not using standard numeric genres, and dump the remainder.
-                        break;
-                    }
-
-                    // Transition to refinement processing
-                    inParentheses = false;
-                    refinementAdded = false;
-                    open = i + 1;
-                }
-
-                // If we didn't find the closing paren, just increment and try again.
-            } else {
-                // Processing refinement  ------------------------------
-                let refinementChunk: string;
-                if (field[i] === "(") {
-                    if (field[i + 1] === "(") {
-                        // This is an escape sequence
-                        // Take the current refinement chunk + the first paren (eg: `xyz(`)
-                        refinementChunk = field.substring(open, i + 1);
-
-
-                        // Skip over the next character (ie, `(`)
-                        open = i + 2;
-                        i++;
-                    } else {
-                        // This is possibly the start of a numeric genre.
-                        // Take the current refinement chunk
-                        refinementChunk = field.substring(open, i);
-
-                        // Transition back to numeric genre processing.
-                        inParentheses = true;
-                        open = i;
-                    }
-
-                    // Add the refinement chunk to the last result
-                    appendToLastResult(refinementChunk);
-                    refinementAdded = true;
-                }
-
-                // If we didn't find an opening paren, just increment and try again
-            }
-        }
-
-        // Process the remainder
-        // If we didn't find any results, then just return undefined.
-        if (results.length === 0) {
-            return undefined;
-        }
-
-        appendToLastResult(field.substring(open));
-        return results;
-    }
 }
 
 export class UserTextInformationFrame extends TextInformationFrame {

--- a/src/id3v2/id3v2Tag.ts
+++ b/src/id3v2/id3v2Tag.ts
@@ -1,5 +1,6 @@
 import AttachmentFrame from "./frames/attachmentFrame";
 import CommentsFrame from "./frames/commentsFrame";
+import GenreFrame from "./frames/genreFrame";
 import Id3v2ExtendedHeader from "./id3v2ExtendedHeader";
 import Id3v2TagFooter from "./id3v2TagFooter";
 import Id3v2Settings from "./id3v2Settings";
@@ -1111,6 +1112,9 @@ export default class Id3v2Tag extends Tag {
         if (ident.isUrlFrame) {
             const frames = this.getFramesByClassType<UrlLinkFrame>(FrameClassType.UrlLinkFrame);
             frame = UrlLinkFrame.findUrlLinkFrame(frames, ident);
+        } else if (ident === FrameIdentifiers.TCON) {
+            const frames = this.getFramesByClassType<GenreFrame>(FrameClassType.GenreFrame);
+            frame = GenreFrame.findGenreFrame(frames);
         } else {
             const frames = this.getFramesByClassType<TextInformationFrame>(FrameClassType.TextInformationFrame);
             frame = TextInformationFrame.findTextInformationFrame(frames, ident);
@@ -1338,11 +1342,21 @@ export default class Id3v2Tag extends Tag {
             return;
         }
 
-        const frames = this.getFramesByClassType<TextInformationFrame>(FrameClassType.TextInformationFrame);
-        let frame = TextInformationFrame.findTextInformationFrame(frames, ident);
-        if (!frame) {
-            frame = TextInformationFrame.fromIdentifier(ident);
-            this.addFrame(frame);
+        let frame: TextInformationFrame|GenreFrame;
+        if (ident === FrameIdentifiers.TCON) {
+            const frames = this.getFramesByClassType<GenreFrame>(FrameClassType.GenreFrame);
+            frame = GenreFrame.findGenreFrame(frames);
+            if (!frame) {
+                frame = GenreFrame.fromEncoding();
+                this.addFrame(frame);
+            }
+        } else {
+            const frames = this.getFramesByClassType<TextInformationFrame>(FrameClassType.TextInformationFrame);
+            frame = TextInformationFrame.findTextInformationFrame(frames, ident);
+            if (!frame) {
+                frame = TextInformationFrame.fromIdentifier(ident);
+                this.addFrame(frame);
+            }
         }
 
         frame.text = text;
@@ -1488,6 +1502,12 @@ export default class Id3v2Tag extends Tag {
     }
 
     private getTextAsArray(ident: FrameIdentifier): string[] {
+        if (ident === FrameIdentifiers.TCON) {
+            const frames = this.getFramesByClassType<GenreFrame>(FrameClassType.GenreFrame);
+            const frame = GenreFrame.findGenreFrame(frames);
+            return frame ? frame.text : [];
+        }
+
         const frames = this.getFramesByClassType<TextInformationFrame>(FrameClassType.TextInformationFrame);
         const frame = TextInformationFrame.findTextInformationFrame(frames, ident);
         return frame ? frame.text : [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,6 +116,7 @@ export {
     SynchronizedText as Id3v2SynchronizedLyricsFrame
 } from "./id3v2/frames/synchronizedLyricsFrame";
 export {default as Id3v2TermsOfUseFrame} from "./id3v2/frames/termsOfUseFrame";
+export {default as Id3v2GenreFrame} from "./id3v2/frames/genreFrame";
 export {
     TextInformationFrame as Id3v2TextInformationFrame,
     UserTextInformationFrame as Id3v2UserTextInformationFrame

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -342,9 +342,18 @@ export class StringUtils {
         return this.ISO369_2_REGEX.test(value);
     }
 
+    public static trimEnd(toTrim: string, chars: string): string {
+        // @TODO: Would a regex be faster?
+        while (toTrim.length > 0 && chars.indexOf(toTrim[toTrim.length - 1]) > -1) {
+            toTrim = toTrim.substring(0, toTrim.length - 1);
+        }
+        return toTrim;
+    }
+
     public static trimStart(toTrim: string, chars: string): string {
+        // @TODO: Would a regex be faster?
         while (toTrim.length > 0 && chars.indexOf(toTrim[0]) > -1) {
-            toTrim = toTrim.substring(0);
+            toTrim = toTrim.substring(1);
         }
         return toTrim;
     }

--- a/test-unit/id3v2/genreFrameTests.ts
+++ b/test-unit/id3v2/genreFrameTests.ts
@@ -10,7 +10,7 @@ import {FrameIdentifiers} from "../../src/id3v2/frameIdentifiers";
 import {Testers} from "../utilities/testers";
 
 @suite
-class Id3v2_TconFrameTests {
+class Id3v2_GenreFrameTests {
 
     // region Property tests
 

--- a/test-unit/id3v2/id3v2TagTests.ts
+++ b/test-unit/id3v2/id3v2TagTests.ts
@@ -3,6 +3,7 @@ import {params, suite, test} from "@testdeck/mocha";
 import {assert} from "chai";
 
 import CommentsFrame from "../../src/id3v2/frames/commentsFrame";
+import GenreFrame from "../../src/id3v2/frames/genreFrame";
 import Id3v2Settings from "../../src/id3v2/id3v2Settings";
 import Id3v2Tag from "../../src/id3v2/id3v2Tag";
 import Id3v2TagFooter from "../../src/id3v2/id3v2TagFooter";
@@ -603,7 +604,7 @@ const getTestTagHeader = (version: number, flags: Id3v2TagHeaderFlags, tagSize: 
     public genres_withFrame() {
         // Arrange
         const tag = Id3v2Tag.fromEmpty();
-        const frame = TextInformationFrame.fromIdentifier(FrameIdentifiers.TCON);
+        const frame = GenreFrame.fromEncoding();
         frame.text = ["Classical", "foo"];
         tag.addFrame(frame);
 
@@ -624,16 +625,16 @@ const getTestTagHeader = (version: number, flags: Id3v2TagHeaderFlags, tagSize: 
 
         // Assert
         assert.strictEqual(tag.frames.length, 1);
-        assert.strictEqual(tag.frames[0].frameClassType, FrameClassType.TextInformationFrame);
+        assert.strictEqual(tag.frames[0].frameClassType, FrameClassType.GenreFrame);
         assert.strictEqual(tag.frames[0].frameId, FrameIdentifiers.TCON);
-        assert.deepStrictEqual((<TextInformationFrame> tag.frames[0]).text, ["Classical", "foo"]);
+        assert.deepStrictEqual((<GenreFrame> tag.frames[0]).text, ["Classical", "foo"]);
     }
 
     @test
     public genres_setValueWithFrame() {
         // Arrange
         const tag = Id3v2Tag.fromEmpty();
-        const frame = TextInformationFrame.fromIdentifier(FrameIdentifiers.TCON);
+        const frame = GenreFrame.fromEncoding();
         frame.text = ["qux"];
         tag.addFrame(frame);
 
@@ -642,9 +643,9 @@ const getTestTagHeader = (version: number, flags: Id3v2TagHeaderFlags, tagSize: 
 
         // Assert
         assert.strictEqual(tag.frames.length, 1);
-        assert.strictEqual(tag.frames[0].frameClassType, FrameClassType.TextInformationFrame);
+        assert.strictEqual(tag.frames[0].frameClassType, FrameClassType.GenreFrame);
         assert.strictEqual(tag.frames[0].frameId, FrameIdentifiers.TCON);
-        assert.deepStrictEqual((<TextInformationFrame> tag.frames[0]).text, ["Classical", "foo"]);
+        assert.deepStrictEqual((<GenreFrame> tag.frames[0]).text, ["Classical", "foo"]);
     }
 
     @test
@@ -660,9 +661,9 @@ const getTestTagHeader = (version: number, flags: Id3v2TagHeaderFlags, tagSize: 
 
             // Assert
             assert.strictEqual(tag.frames.length, 1);
-            assert.strictEqual(tag.frames[0].frameClassType, FrameClassType.TextInformationFrame);
+            assert.strictEqual(tag.frames[0].frameClassType, FrameClassType.GenreFrame);
             assert.strictEqual(tag.frames[0].frameId, FrameIdentifiers.TCON);
-            assert.deepStrictEqual((<TextInformationFrame> tag.frames[0]).text, ["Classical", "foo"]);
+            assert.deepStrictEqual((<GenreFrame> tag.frames[0]).text, ["Classical", "foo"]);
         } finally {
             Id3v2Settings.useNumericGenres = initialSetting;
         }

--- a/test-unit/id3v2/tconFrameTests.ts
+++ b/test-unit/id3v2/tconFrameTests.ts
@@ -2,10 +2,10 @@ import {suite, test} from "@testdeck/mocha";
 import {assert} from "chai";
 
 import Id3v2Settings from "../../src/id3v2/id3v2Settings";
+import GenreFrame from "../../src/id3v2/frames/genreFrame";
 import {ByteVector, StringType} from "../../src/byteVector";
 import {Id3v2FrameFlags, Id3v2FrameHeader} from "../../src/id3v2/frames/frameHeader";
 import {FrameIdentifiers} from "../../src/id3v2/frameIdentifiers";
-import {TextInformationFrame} from "../../src/id3v2/frames/textInformationFrame";
 import {Testers} from "../utilities/testers";
 
 @suite
@@ -170,6 +170,24 @@ class Id3v2_TconFrameTests {
         );
     }
 
+    @test
+    public parse_v4ListOfStrings() {
+        const payload = ByteVector.concatenate(
+            StringType.UTF16BE,
+            ByteVector.fromString("32", StringType.UTF16BE),
+            ByteVector.getTextDelimiter(StringType.UTF16BE),
+            ByteVector.fromString("(32)", StringType.UTF16BE),
+            ByteVector.getTextDelimiter(StringType.UTF16BE),
+            ByteVector.fromString("some genre", StringType.UTF16BE)
+        );
+
+        this.testFrameParse(4, payload, [
+            "Classical",
+            "(32)",
+            "some genre"
+        ]);
+    }
+
     // endregion
 
     // region Render tests
@@ -246,7 +264,7 @@ class Id3v2_TconFrameTests {
         const header = new Id3v2FrameHeader(FrameIdentifiers.TCON, Id3v2FrameFlags.None, bodyBytes.length);
 
         const frameBytes = ByteVector.concatenate(header.render(tagVersion), bodyBytes);
-        const frame = TextInformationFrame.fromOffsetRawData(frameBytes, 0, header, tagVersion);
+        const frame = GenreFrame.fromOffsetRawData(frameBytes, 0, header, tagVersion);
 
         // Act
         const values = frame.text;
@@ -267,7 +285,7 @@ class Id3v2_TconFrameTests {
 
     private testFrameRender(tagVersion: number, fields: string[], expected: string) {
         // Arrange
-        const frame = TextInformationFrame.fromIdentifier(FrameIdentifiers.TCON);
+        const frame = GenreFrame.fromEncoding();
         frame.textEncoding = StringType.UTF16BE;
         frame.text = fields;
 

--- a/test-unit/id3v2/tconFrameTests.ts
+++ b/test-unit/id3v2/tconFrameTests.ts
@@ -4,12 +4,68 @@ import {assert} from "chai";
 import Id3v2Settings from "../../src/id3v2/id3v2Settings";
 import GenreFrame from "../../src/id3v2/frames/genreFrame";
 import {ByteVector, StringType} from "../../src/byteVector";
+import {FrameClassType} from "../../src/id3v2/frames/frame";
 import {Id3v2FrameFlags, Id3v2FrameHeader} from "../../src/id3v2/frames/frameHeader";
 import {FrameIdentifiers} from "../../src/id3v2/frameIdentifiers";
 import {Testers} from "../utilities/testers";
 
 @suite
 class Id3v2_TconFrameTests {
+
+    // region Property tests
+
+    @test
+    public fromEncoding() {
+        // Act
+        const frame = GenreFrame.fromEncoding(StringType.UTF16BE);
+
+        // Assert
+        assert.isOk(frame);
+        assert.strictEqual(frame.frameClassType, FrameClassType.GenreFrame);
+        assert.strictEqual(frame.frameId, FrameIdentifiers.TCON);
+        assert.deepStrictEqual(frame.text, []);
+        assert.strictEqual(frame.textEncoding, StringType.UTF16BE);
+    }
+
+    @test
+    public text_returnsCopy() {
+        // Arrange
+        const frame = GenreFrame.fromEncoding();
+        frame.text = ["foo", "bar"];
+
+        // Act
+        const text = frame.text;
+        text.push("baz");
+
+        // Assert
+        assert.deepStrictEqual(frame.text, ["foo", "bar"]);
+    }
+
+    @test
+    public text_setFalsyReturnsEmptyArray() {
+        // Arrange
+        const frame = GenreFrame.fromEncoding();
+
+        // Act
+        frame.text = undefined;
+
+        // Assert
+        assert.deepStrictEqual(frame.text, []);
+    }
+
+    @test
+    public textEncoding() {
+        // Arrange
+        const frame = GenreFrame.fromEncoding();
+
+        // Act
+        frame.textEncoding = StringType.UTF16BE;
+
+        // Assert
+        assert.strictEqual(frame.textEncoding, StringType.UTF16BE);
+    }
+
+    // endregion
 
     // region Parse Tests
 
@@ -171,6 +227,22 @@ class Id3v2_TconFrameTests {
     }
 
     @test
+    public parse_v2V3EmptyFrame() {
+        this.testFrameParseV2V3(ByteVector.concatenate(StringType.UTF16BE), []);
+    }
+
+    @test
+    public parse_v2V3StartsWithDelimiter() {
+        const payload = ByteVector.concatenate(
+            StringType.UTF16BE,
+            ByteVector.getTextDelimiter(StringType.UTF16BE),
+            ByteVector.fromString("foo", StringType.UTF16BE)
+        );
+
+        this.testFrameParseV2V3(payload, []);
+    }
+
+    @test
     public parse_v4ListOfStrings() {
         const payload = ByteVector.concatenate(
             StringType.UTF16BE,
@@ -186,6 +258,59 @@ class Id3v2_TconFrameTests {
             "(32)",
             "some genre"
         ]);
+    }
+
+    @test
+    public parse_v4CoverRemix() {
+        this.testFrameParseV4(["CR"], ["Cover"]);
+        this.testFrameParseV4(["RX"], ["Remix"]);
+    }
+
+    @test
+    public parse_v4CoverRemixWithRefinement() {
+        this.testFrameParseV4(["CR foo", "RX bar"], ["CR foo", "RX bar"]);
+    }
+
+    @test
+    public parse_v4CoverRemixWithParentheses() {
+        this.testFrameParseV4(["(CR)", "(RX)"], ["(CR)", "(RX)"]);
+    }
+
+    @test
+    public parse_v4CoverRemixWithEscapedParentheses() {
+        this.testFrameParseV4(["CR f((oo", "RX b((ar"], ["CR f((oo", "RX b((ar"]);
+    }
+
+    @test
+    public parse_v4CoverRemixWithUnescapedParentheses() {
+        this.testFrameParseV4(["CR f(oo", "RX b(ar"], ["CR f(oo", "RX b(ar"]);
+    }
+
+    @test
+    public parse_v2V3WithTrailingNulls() {
+        const payload = ByteVector.concatenate(
+            StringType.UTF16BE,
+            ByteVector.fromString("(32)", StringType.UTF16BE),
+            ByteVector.getTextDelimiter(StringType.UTF16BE),
+            ByteVector.getTextDelimiter(StringType.UTF16BE)
+        );
+
+        this.testFrameParse(2, payload, ["Classical"]);
+        this.testFrameParse(3, payload, ["Classical"]);
+    }
+
+    @test
+    public parse_v4WithTrailingNulls() {
+        const payload = ByteVector.concatenate(
+            StringType.UTF16BE,
+            ByteVector.fromString("32", StringType.UTF16BE),
+            ByteVector.getTextDelimiter(StringType.UTF16BE),
+            ByteVector.fromString("CR", StringType.UTF16BE),
+            ByteVector.getTextDelimiter(StringType.UTF16BE),
+            ByteVector.getTextDelimiter(StringType.UTF16BE)
+        );
+
+        this.testFrameParse(4, payload, ["Classical", "Cover"]);
     }
 
     // endregion
@@ -250,6 +375,137 @@ class Id3v2_TconFrameTests {
         this.testFrameRenderV2V3(["Classical foo", "Instrumental bar"], "Classical foo;Instrumental bar");
     }
 
+    @test
+    public render_v4SingleTermString() {
+        this.testFrameRenderV4(["foobarbaz"], ["foobarbaz"]);
+    }
+
+    @test
+    public render_v4MultipleTermsString() {
+        this.testFrameRenderV4(["foo","bar","baz"], ["foo","bar","baz"]);
+    }
+
+    @test
+    public render_v4SingleTerm_numericString_useNumericGenresEnabled() {
+        const settings: PartialSettings = { useNumericGenres: true };
+        this.testFrameRenderV4WithSettings(settings, ["Classical"], ["32"]);
+    }
+
+    @test
+    public render_v4SingleTerm_numericString_useNumericGenresDisabled() {
+        const settings: PartialSettings = { useNumericGenres: false };
+        this.testFrameRenderV4WithSettings(settings, ["Classical"], ["Classical"]);
+    }
+
+    @test
+    public render_v4SingleTerm_coverRemixString_useNumericGenresEnabled() {
+        const settings: PartialSettings = { useNumericGenres: true };
+        this.testFrameRenderV4WithSettings(settings, ["Cover"], ["CR"]);
+        this.testFrameRenderV4WithSettings(settings, ["Remix"], ["RX"]);
+    }
+
+    @test
+    public render_v4SingleTerm_coverRemixString_useNumericGenresDisabled() {
+        const settings: PartialSettings = { useNumericGenres: false };
+        this.testFrameRenderV4WithSettings(settings, ["Cover"], ["CR"]);
+        this.testFrameRenderV4WithSettings(settings, ["Remix"], ["RX"]);
+    }
+
+    @test
+    public render_v4MultipleTerms_numericGenre_useNumericGenresEnabled() {
+        const settings: PartialSettings = { useNumericGenres: true };
+        this.testFrameRenderV4WithSettings(
+            settings,
+            ["Classical", "Instrumental", "foo"],
+            ["32", "33", "foo"]
+        );
+    }
+
+    @test
+    public render_v4MultipleTerms_numericGenre_useNumericGenresDisabled() {
+        const settings: PartialSettings = { useNumericGenres: false };
+        this.testFrameRenderV4WithSettings(
+            settings,
+            ["Classical", "Instrumental", "foo"],
+            ["Classical", "Instrumental", "foo"]
+        );
+    }
+
+    @test
+    public render_v4MultipleTerms_numericGenreWithRefinement() {
+        this.testFrameRenderV4(
+            ["Classical foo", "Instrumental bar"],
+            ["Classical foo", "Instrumental bar"]
+        );
+    }
+
+    @test
+    public render_v4EmptyTerms() {
+        this.testFrameRenderV4(["foo", undefined, "", "bar"], ["foo", undefined, "", "bar"]);
+    }
+
+    // endregion
+
+    // region Method tests
+
+    @test
+    public clone_returnsCopy() {
+        // Arrange
+        const frame = GenreFrame.fromEncoding(StringType.UTF16BE);
+        frame.text = ["foo", "bar"];
+
+        // Act
+        const output = <GenreFrame> frame.clone();
+
+        // Assert
+        assert.isOk(output);
+        assert.notStrictEqual(output, frame);
+        assert.strictEqual(output.frameClassType, FrameClassType.GenreFrame);
+        assert.strictEqual(output.frameId, FrameIdentifiers.TCON);
+        assert.deepStrictEqual(output.text, ["foo", "bar"]);
+        assert.strictEqual(output.textEncoding, StringType.UTF16BE);
+    }
+
+    @test
+    public find_falsyFrames() {
+        // Act/Assert
+        Testers.testTruthy((v: GenreFrame[]) => { GenreFrame.findGenreFrame(v); });
+    }
+
+    @test
+    public find_frameExists() {
+        // Arrange
+        const frame = GenreFrame.fromEncoding();
+
+        // Act
+        const output = GenreFrame.findGenreFrame([frame]);
+
+        // Assert
+        assert.strictEqual(output, frame);
+    }
+
+    @test
+    public find_frameDoesNotExist() {
+        // Act
+        const output = GenreFrame.findGenreFrame([]);
+
+        // Assert
+        assert.isUndefined(output);
+    }
+
+    @test
+    public toString_returnsSemicolonSeparatedText() {
+        // Arrange
+        const frame = GenreFrame.fromEncoding();
+        frame.text = ["foo", "bar"];
+
+        // Act
+        const output = frame.toString();
+
+        // Assert
+        assert.strictEqual(output, "foo; bar");
+    }
+
     // endregion
 
     private testFrameParse(tagVersion: number, payload: string|ByteVector, expected: string[]) {
@@ -273,7 +529,7 @@ class Id3v2_TconFrameTests {
         assert.deepStrictEqual(values, expected);
     }
 
-    private testFrameParseV2V3(payload: string, expected: string[]) {
+    private testFrameParseV2V3(payload: string|ByteVector, expected: string[]) {
         this.testFrameParse(2, payload, expected);
         this.testFrameParse(3, payload, expected);
     }
@@ -281,6 +537,15 @@ class Id3v2_TconFrameTests {
     private testFrameParseV2V3WithSettings(settings: PartialSettings, payload: string, expected: string[]) {
         const action = () => { this.testFrameParseV2V3(payload, expected); };
         this.testWithSettings(settings, action);
+    }
+
+    private testFrameParseV4(fields: string[], expected: string[]) {
+        const payload = ByteVector.concatenate(
+            StringType.UTF16BE,
+            ... this.getDelimitedStrings(fields)
+        );
+
+        this.testFrameParse(4, payload, expected);
     }
 
     private testFrameRender(tagVersion: number, fields: string[], expected: string) {
@@ -309,6 +574,32 @@ class Id3v2_TconFrameTests {
         Testers.bvEqual(result, expectedBytes);
     }
 
+    private testFrameRenderV4(fields: string[], expected: string[]) {
+        // Arrange
+        const frame = GenreFrame.fromEncoding();
+        frame.textEncoding = StringType.UTF16BE;
+        frame.text = fields;
+
+        // Act
+        const result = frame.render(4);
+
+        // Assert
+        const expectedBody = ByteVector.concatenate(
+            StringType.UTF16BE,
+            ... this.getDelimitedStrings(expected)
+        );
+
+        const expectedHeader = Id3v2FrameHeader.fromFrameIdentifier(FrameIdentifiers.TCON);
+        expectedHeader.frameSize = expectedBody.length;
+
+        const expectedBytes = ByteVector.concatenate(
+            expectedHeader.render(4),
+            expectedBody
+        );
+
+        Testers.bvEqual(result, expectedBytes);
+    }
+
     private testFrameRenderV2V3(fields: string[], expected: string) {
         this.testFrameRender(2, fields, expected);
         this.testFrameRender(3, fields, expected);
@@ -317,6 +608,26 @@ class Id3v2_TconFrameTests {
     private testFrameRenderV2V3WithSettings(settings: PartialSettings, fields: string[], expected: string) {
         const action = () => { this.testFrameRenderV2V3(fields, expected); };
         this.testWithSettings(settings, action);
+    }
+
+    private testFrameRenderV4WithSettings(settings: PartialSettings, fields: string[], expected: string[]) {
+        const action = () => { this.testFrameRenderV4(fields, expected); };
+        this.testWithSettings(settings, action);
+    }
+
+    private getDelimitedStrings(fields: string[]): Array<ByteVector|number> {
+        const parts = [];
+        for (let i = 0; i < fields.length; i++) {
+            if (i !== 0) {
+                parts.push(ByteVector.getTextDelimiter(StringType.UTF16BE));
+            }
+
+            if (fields[i]) {
+                parts.push(ByteVector.fromString(fields[i], StringType.UTF16BE));
+            }
+        }
+
+        return parts;
     }
 
     private testWithSettings(settings: PartialSettings, action: () => void) {

--- a/test-unit/id3v2/textInformationFrameTests.ts
+++ b/test-unit/id3v2/textInformationFrameTests.ts
@@ -141,38 +141,6 @@ const getTestFrame = (): TextInformationFrame => {
     }
 
     @test
-    public fromOffsetRawData_v4Tcon_returnsListOfStrings() {
-        // Arrange
-        const header = new Id3v2FrameHeader(FrameIdentifiers.TCON);
-        header.frameSize = 37;
-        const data = ByteVector.concatenate(
-            0x00, 0x00,
-            header.render(4),
-            StringType.UTF16BE,
-            ByteVector.fromString("32", StringType.UTF16BE),
-            ByteVector.getTextDelimiter(StringType.UTF16BE),
-            ByteVector.fromString("(32)", StringType.UTF16BE),
-            ByteVector.getTextDelimiter(StringType.UTF16BE),
-            ByteVector.fromString("some genre", StringType.UTF16BE)
-        );
-
-        // Act
-        const frame = TextInformationFrame.fromOffsetRawData(data, 2, header, 4);
-
-        // Assert
-        Id3v2_TextInformationFrame_ConstructorTests.assertFrame(
-            frame,
-            FrameIdentifiers.TCON,
-            [
-                "Classical",
-                "(32)",
-                "some genre"
-            ],
-            StringType.UTF16BE
-        );
-    }
-
-    @test
     public fromOffsetRawData_v4_returnsFrameSplitByDelimiter() {
         // Arrange
         const header = new Id3v2FrameHeader(FrameIdentifiers.TCOP);

--- a/test-unit/utilsTests.ts
+++ b/test-unit/utilsTests.ts
@@ -1,0 +1,117 @@
+import {params, suite} from "@testdeck/mocha";
+import {assert} from "chai";
+
+import {StringUtils} from "../src/utils";
+
+@suite class StringUtils_Tests {
+    // #region trimEnd Tests
+
+    @params(["",          ""],          "empty_string")
+    @params(["foobarbaz", "foobarbaz"], "no_match")
+    @params(["fooaaaaaa", "foo"],       "trailing")
+    @params(["aaaaaafoo", "aaaaaafoo"], "leading")
+    @params(["fooaaafoo", "fooaaafoo"], "center")
+    public trimEnd_singleCharacter([input, output]: [string, string]) {
+        // Act
+        const result = StringUtils.trimEnd(input, "a");
+
+        // Assert
+        assert.strictEqual(result, output);
+    }
+
+    @params(["",          ""],          "empty_string")
+    @params(["foobarbaz", "foobarbaz"], "no_match")
+    @params(["fooabcabc", "foo"],       "trailing")
+    @params(["abcabcfoo", "abcabcfoo"], "leading")
+    @params(["fooabcfoo", "fooabcfoo"], "center")
+    public trimEnd_multipleCharacter([input, output]: [string, string]) {
+        // Act
+        const result = StringUtils.trimEnd(input, "abc");
+
+        // Assert
+        assert.strictEqual(result, output);
+    }
+
+    @params(["",             ""],             "empty_string")
+    @params(["foobarbaz",    "foobarbaz"],    "no_match")
+    @params(["foo\0\0\0",    "foo"],          "trailing")
+    @params(["\0\0\0foo",    "\0\0\0foo"],    "leading")
+    @params(["foo\0\0\0foo", "foo\0\0\0foo"], "center")
+    public trimEnd_nullByte([input, output]: [string, string]) {
+        // Act
+        const result = StringUtils.trimEnd(input, "\0");
+
+        // Assert
+        assert.strictEqual(result, output);
+    }
+
+    @params(["",              ""],              "empty_string")
+    @params(["foobarbaz",     "foobarbaz"],     "no_match")
+    @params(["foo \t\r\n",    "foo"],           "trailing")
+    @params([" \t\r\nfoo",    " \t\r\nfoo"],    "leading")
+    @params(["foo \t\r\nfoo", "foo \t\r\nfoo"], "center")
+    public trimEnd_whitespace([input, output]: [string, string]) {
+        // Act
+        const result = StringUtils.trimEnd(input, " \t\r\n");
+
+        // Assert
+        assert.strictEqual(result, output);
+    }
+
+    // #endregion
+    // #region trimStart Tests
+
+    @params(["",          ""],          "empty_string")
+    @params(["foobarbaz", "foobarbaz"], "no_match")
+    @params(["fooaaaaaa", "fooaaaaaa"], "trailing")
+    @params(["aaaaaafoo", "foo"],       "leading")
+    @params(["fooaaafoo", "fooaaafoo"], "center")
+    public trimStart_singleCharacter([input, output]: [string, string]) {
+        // Act
+        const result = StringUtils.trimStart(input, "a");
+
+        // Assert
+        assert.strictEqual(result, output);
+    }
+
+    @params(["",          ""],          "empty_string")
+    @params(["foobarbaz", "foobarbaz"], "no_match")
+    @params(["fooabcabc", "fooabcabc"], "trailing")
+    @params(["abcabcfoo", "foo"],       "leading")
+    @params(["fooabcfoo", "fooabcfoo"], "center")
+    public trimStart_multipleCharacter([input, output]: [string, string]) {
+        // Act
+        const result = StringUtils.trimStart(input, "abc");
+
+        // Assert
+        assert.strictEqual(result, output);
+    }
+
+    @params(["",             ""],             "empty_string")
+    @params(["foobarbaz",    "foobarbaz"],    "no_match")
+    @params(["foo\0\0\0",    "foo\0\0\0"],    "trailing")
+    @params(["\0\0\0foo",    "foo"],          "leading")
+    @params(["foo\0\0\0foo", "foo\0\0\0foo"], "center")
+    public trimStart_nullByte([input, output]: [string, string]) {
+        // Act
+        const result = StringUtils.trimStart(input, "\0");
+
+        // Assert
+        assert.strictEqual(result, output);
+    }
+
+    @params(["",              ""],              "empty_string")
+    @params(["foobarbaz",     "foobarbaz"],     "no_match")
+    @params(["foo \t\r\n",    "foo \t\r\n"],    "trailing")
+    @params([" \t\r\nfoo",    "foo"],           "leading")
+    @params(["foo \t\r\nfoo", "foo \t\r\nfoo"], "center")
+    public trimStart_whitespace([input, output]: [string, string]) {
+        // Act
+        const result = StringUtils.trimStart(input, " \t\r\n");
+
+        // Assert
+        assert.strictEqual(result, output);
+    }
+
+    // #endregion
+}


### PR DESCRIPTION
## Description
Finally splitting the text information frame class into a separate TCON frame. This frame has special behavior for how genres are handled, and it was getting cumbersome to have all the different cases within the text information frame class.

As an added benefit, I fixed a bug in AIFF behavior where null bytes aren't being trimmed from the start of some field somewhere (ie, there was a bug in StringUtils.trimStart)

This will be prerequisite work for applying the same eager loading that we just did in URL frames.

## 🤖 
Most of this was coded by codex. The commits that were mostly written by codex are prefixed with 🤖 